### PR TITLE
Fix: DebugLog.on_result_judge() KeyError: 'judge'

### DIFF
--- a/ikalog/outputs/debug.py
+++ b/ikalog/outputs/debug.py
@@ -87,7 +87,7 @@ class DebugLog(object):
 
     def on_result_judge(self, context):
         s = "judge: %s, knockout: %s" % (
-            context['game']['judge'], context['game'].get('knockout', None))
+            context['game'].get('judge', None), context['game'].get('knockout', None))
 
         self.write_debug_log(sys._getframe().f_code.co_name, context,
                              text=s)


### PR DESCRIPTION
例外が上がってたので1行パッチです。

```
DebugLog.on_result_judge() raised a exception >>>>
Traceback (most recent call last):
  File "/Users/kshimo69/repos/IkaLog/ikalog/engine.py", line 50, in call_plugins
    getattr(op, event_name)(self.context)
  File "/Users/kshimo69/repos/IkaLog/ikalog/outputs/debug.py", line 90, in on_result_judge
    context['game']['judge'], context['game'].get('knockout', None))
KeyError: 'judge'

<<<<<
```