### PR TITLE
fix small error

### DIFF
--- a/ikalog/inputs/cvcapture.py
+++ b/ikalog/inputs/cvcapture.py
@@ -89,7 +89,7 @@ class InputSourceEnumerator(object):
                 self.dll.VI_GetDeviceName.argtypes = []
             except:
                 IkaUtils.dprint(
-                    "%s: Failed to initalize %s" % self, videoinput_dll)
+                    "%s: Failed to initalize %s" % (self, videoinput_dll))
 
 
 class CVCapture(object):


### PR DESCRIPTION
# 概要
Windowsでキャプチャデバイスが取れなかったときのエラー出力が壊れていたので修正しました。