### PR TITLE
INSTALLドキュメントの更新

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -41,15 +41,15 @@ URL:
   http://www.lfd.uci.edu/~gohlke/pythonlibs/
 
 ダウンロードするファイル:
-  numpy‑1.9.2+mkl‑cp34‑none‑win32.whl
+  numpy‑1.9.3+mkl‑cp34‑none‑win32.whl
   opencv_python‑3.0.0‑cp34‑none‑win32.whl
 
 ※ cp34 は CPython 3.4, win32 は 32bit 版を示している
 
 ■ インストール作業
 
-cd c:\IkaLog\Python34\Script
-pip install "C:\IkaLog\Archives\numpy-1.9.2+mkl-cp34-none-win32.whl"
+cd c:\IkaLog\Python34\Scripts
+pip install "C:\IkaLog\Archives\numpy-1.9.3+mkl-cp34-none-win32.whl"
 pip install "C:\IkaLog\Archives\opencv_python-3.0.0-cp34-none-win32.whl"
 pip install slackweb
 pip install fluent-logger


### PR DESCRIPTION
Windowsで開発版を試したくINSTALLを参照していたところ、
2015/10/22 23:00+JST時点でnumpyの配布バージョンに1.9.2が消滅していたため、
マイナーバージョンアップ版である1.9.3に変更。
numpy-1.10.1もでてるのでそちらで動作テストできれば適宜アップデートしたい。
加えてpipの存在するディレクトリ名が少々違っていた部分を修正。

あとwikiの開発環境の構築の項でwindows版が未作成なので、このドキュメントをそのままmarkdown化して持っていくのはどうでしょうか。