### PR TITLE
output/statink: API parameter that related to splatfest has been renamed

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -356,8 +356,8 @@ class StatInk(object):
                 payload['weapon'] = weapon
 
         if context['game']['is_fes']:
-            payload['fest_gender'] = me['gender_en']
-            payload['fest_rank'] = me['prefix_en']
+            payload['gender'] = me['gender_en']
+            payload['fest_title'] = str(me['prefix_en']).lower()
 
         self._set_values(
             [  # 'type', 'stat.ink Field', 'IkaLog Field'


### PR DESCRIPTION
https://github.com/fetus-hina/stat.ink/issues/22 の通り、

- `fest_gender` -> `gender`
- `fest_rank` -> `fest_title`

と変更するパッチです。
たぶんこの実装でいいと思うのですが、文法的に合っているか以上のチェックができていません。
大変お手数ですが確認と必要であれば修正をお願いします。