### PR TITLE
Using Certifi with urllib3

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -23,6 +23,7 @@ import os
 import pprint
 
 import urllib3
+import certifi
 import umsgpack
 from ikalog.version import IKALOG_VERSION
 from ikalog.utils import *
@@ -488,11 +489,19 @@ class StatInk(object):
         mp_payload_bytes = umsgpack.packb(payload)
         mp_payload = ''.join(map(chr, mp_payload_bytes))
 
-        pool = urllib3.PoolManager()
-        req = pool.urlopen('POST', url_statink_v1_battle,
-                           headers=http_headers,
-                           body=mp_payload,
-                           )
+        pool = urllib3.PoolManager(
+            cert_reqs = 'CERT_REQUIRED', # Force certificate check
+            ca_certs = certifi.where(),  # Path to the Certifi bundle.
+        )
+
+        try:
+            req = pool.urlopen('POST', url_statink_v1_battle,
+                               headers=http_headers,
+                               body=mp_payload,
+                               )
+        except urllib3.exceptions.SSLError as e:
+            # Handle incorrect certificate error.
+            print 'SSLError, value:', e.value
 
         if self.show_response_enabled:
             print(req.data.decode('utf-8'))


### PR DESCRIPTION
http://urllib3.readthedocs.org/en/latest/security.html#using-certifi-with-urllib3

コード変更後に各環境で下記コマンドを実行する。

```
pip3 install certifi
```

stat.ink へは https で接続しているため以下の警告が出力されていた。

```
/usr/local/lib/python3.5/site-packages/urllib3/connectionpool.py:789: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
```