### PR TITLE
Send h3reelgun_d to stat.ink

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -157,6 +157,7 @@ class StatInk(object):
                 'デュアルスイーパー': 'dualsweeper',
                 'デュアルスイーパーカスタム': 'dualsweeper_custom',
                 'H3リールガン': 'h3reelgun',
+                'H3リールガンD': 'h3reelgun_d',
                 'ヒーローシューターレプリカ': 'heroshooter_replica',
                 'ホットブラスター': 'hotblaster',
                 'ホットブラスターカスタム': 'hotblaster_custom',


### PR DESCRIPTION
H3リールガンD を stat.ink に送信する。

https://github.com/hasegaw/IkaLog/commit/752103f895bd58697cc04b73c8fc0923aabd63e9

このコミットで stat.ink に送信する定義が抜けていた。

Signed-off-by: Death <deathmetalland@gmail.com>

fixes #9