### PR TITLE
WinIkaLogで棒読みちゃんのテストボタンが動かない問題を修正

### DIFF
--- a/ikalog/outputs/boyomi.py
+++ b/ikalog/outputs/boyomi.py
@@ -207,7 +207,7 @@ class Boyomi(Commentator):
         self.apply_ui()
 
     def on_test_button_click(self, event):
-        self._read(self.custom_read['initialize'])
+        self._read_event('initialize')
 
     def on_option_tab_create(self, notebook):
         self.panel = wx.Panel(notebook, wx.ID_ANY)


### PR DESCRIPTION
#80 で埋め込んだバグです。
設定UIの棒読みちゃん動作テストボタンのコードが古いままでした。