### PR TITLE
outputs/mikumikumouth: fix cleanup problem

### DIFF
--- a/ikalog/outputs/mikumikumouth.py
+++ b/ikalog/outputs/mikumikumouth.py
@@ -108,3 +108,6 @@ class MikuMikuMouth(Commentator):
 
         message["tag"] = "white"
         self._server.talk(message)
+
+    def on_stop(self, context):
+        self._server.close()


### PR DESCRIPTION
プラグインが有効で実際にみくみくまうすとの通信が確立されているときに
IkaLogのシャットダウンが行えない(bye!で固まる)問題を修正します