### PR TITLE
生きているイカをstat.inkへ送る

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -112,6 +112,7 @@ class IkaEngine:
             'dead': False,
             'death_reasons': {},
 
+            'inkling_state': [None, None],
             'livesTrack': [],
             'towerTrack': [],
         }
@@ -257,6 +258,7 @@ class IkaEngine:
             scenes.PaintScoreTracker(self),
             scenes.ObjectiveTracker(self),
             scenes.SplatzoneTracker(self),
+            scenes.InklingsTracker(self),
 
             scenes.ResultDetail(self),
             scenes.ResultUdemae(self),

--- a/ikalog/outputs/debug.py
+++ b/ikalog/outputs/debug.py
@@ -60,6 +60,9 @@ class DebugLog(object):
         s = "weapon = %s" % (context['game']['last_death_reason'])
         self.write_debug_log(sys._getframe().f_code.co_name, context, text=s)
 
+    def on_game_inkling_state_update(self, context):
+        self.write_debug_log(sys._getframe().f_code.co_name, context)
+
     def on_game_go_sign(self, context):
         self.write_debug_log(sys._getframe().f_code.co_name, context)
 

--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -638,6 +638,15 @@ class StatInk(object):
             self.last_dead_event['reason'] = reason
             self.last_dead_event = None
 
+    def on_game_inkling_state_update(self, context):
+        if ('msec' in context['engine']) and (self.time_start_at_msec is not None):
+            states = context['game']['inkling_state']
+            self._add_event(context, {
+                'type': 'alive_inklings',
+                'my_team': states[0],
+                'his_team': states[1],
+            })
+
     def on_game_paint_score_update(self, context):
         score = context['game'].get('paint_score', 0)
         if (score > 0 and 'msec' in context['engine']) and (self.time_start_at_msec is not None):

--- a/ikalog/scenes/__init__.py
+++ b/ikalog/scenes/__init__.py
@@ -30,6 +30,7 @@ from .game.paint_score_tracker import PaintScoreTracker
 from .game.objective_tracker import ObjectiveTracker
 from .game.splatzone_tracker import SplatzoneTracker
 from .game.ranked_battle_events import GameRankedBattleEvents
+from .game.inklings_tracker import InklingsTracker
 
 from .result_detail import ResultDetail
 from .result_judge import ResultJudge


### PR DESCRIPTION
commit 6edb3ca:

クラス構成変更以来長らく全く使われていなかった `InklingsTracker` を魔改造しています。（足りていない定数とかを旧ソースからコピペしてとりあえず動いているように見えますが適切かどうか判断できるPython力と画像処理力がありません）

「とりあえずこうやっておけば動くんじゃないかなあ」というレベルの改造なので、旧contextとの整合性は考えていません。そのため、`context['livesTrack']`は適切に更新されていません。（悪化もしていません）

`context['livesTrack']` を使っている、GUIのTimelineは相変わらず動きませんが、イベント `on_game_inkling_state_update` をハンドルするように変更すれば動くようになると思います（前とはイベントの扱いが違うのでプラグイン側で時系列データに変更する必要はあります）。

CSV出力も触っていないので同様に動きません。

----

commit 5228107:

6edb3ca で作った構造とイベントを利用してstat.inkに追加のイベントを送りつけます。

```js
[
  {"at":0,"type":"alive_inklings","my_team":[true,true,true,true],"his_team":[true,true,true,true]},
  {"at":16.1,"type":"alive_inklings","my_team":[true,true,false,true],"his_team":[true,true,true,true]},
  // ...
]
```

まだstat.ink側に対応が入っていないので表示上は何も変わりません。