### PR TITLE
l10n用のlanguagesを効くようにした

### DIFF
--- a/ikalog/utils/localization.py
+++ b/ikalog/utils/localization.py
@@ -98,7 +98,7 @@ class Localization(object):
                 'locale'
             )
 
-        return gettext.translation(domain, localdir, fallback=True)
+        return gettext.translation(domain, localdir, languages, fallback=True)
 
     @staticmethod
     def print_language_settings():


### PR DESCRIPTION
宙ぶらりんの変数があったので紐付け
将来的に、languagesを設定ファイル等で指定した時にも使えるようになった

（Win10の環境でなぜかgettextから環境変数が取得できなかったのでこれで対処できた）