### PR TITLE
サンプルコードのパターン4で select_source を使うように変更

### DIFF
--- a/IkaConfig.py.sample
+++ b/IkaConfig.py.sample
@@ -42,7 +42,7 @@ class IkaConfig:
         # パターン4: Mac 上で AVFoundation を介してキャプチャデバイスを利用
         # 現在 UltraStudio Mini Recorder のみ動作確認
         # source = inputs.AVFoundationCapture()
-        # source.select_device(THE_DEVICE_ID)
+        # source.select_source(THE_DEVICE_ID)
 
         # パターン5: OpenCV のビデオファイル読み込み機能を利用する
         # OpenCV が FFMPEG に対応していること


### PR DESCRIPTION
サンプルコードのまま実行したら、下記エラーが発生しました。

'AVFoundationCapture' object has no attribute 'select_device'

以前のサンプルをもとに start_camera を使ってみましたが、これは非推奨ということで、 select_source を使うようにと表示され、 select_source を使って動作確認できました。

Signed-off-by: Death <deathmetalland@gmail.com>