### PR TITLE
サンプルコードのパターン5でも select_source を使うように変更

### DIFF
--- a/IkaConfig.py.sample
+++ b/IkaConfig.py.sample
@@ -47,7 +47,7 @@ class IkaConfig:
         # パターン5: OpenCV のビデオファイル読み込み機能を利用する
         # OpenCV が FFMPEG に対応していること
         # source = inputs.CVFile()
-        # source.start_video_file(name='video.avi')
+        # source.select_source(name='video.avi')
         # source.set_frame_rate(10)
 
         # パターン6: OpenCV の GStreamerパイプラインからの読み込み機能を利用する


### PR DESCRIPTION
サンプルコードのまま実行したら、下記警告が発生しました。

start_video_file() is deprcated. Use select_source(name="filename.mp4")

start_video_file のままでも動作しましたが、これは非推奨ということで、 select_source を使って動作確認できました。

Signed-off-by: Death <deathmetalland@gmail.com>