### PR TITLE
フェスで新しい称号「スーパー」をゲットすると stat.ink に送信できない

### DIFF
--- a/ikalog/utils/character_recoginizer/fes_level.py
+++ b/ikalog/utils/character_recoginizer/fes_level.py
@@ -49,7 +49,7 @@ class FesLevelRecoginizer(CharacterRecoginizer):
 
         return {
             '0': {'ja': 'ふつうの', 'boy': 'Fanboy',   'girl': 'Fangirl', },
-            '1': {'ja': 'まことの', 'boy': 'Friend',   'girl': 'Friend', },
+            '1': {'ja': 'まことの', 'boy': 'Fiend',   'girl': 'Fiend', },
             '2': {'ja': 'スーパー', 'boy': 'Defender', 'girl': 'Defender', },
             '3': {'ja': 'カリスマ', 'boy': 'Champion', 'girl': 'Champion', },
             '4': {'ja': 'えいえんの', 'boy': 'King',   'girl': 'Queen'},


### PR DESCRIPTION
下記エラーが発生していました。

```
StatInk.on_game_session_end() raised a exception >>>>
Traceback (most recent call last):
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/engine.py", line 224, in _main_loop
    self.process_frame()
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/engine.py", line 177, in process_frame
    frame, t = self.read_next_frame()
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/engine.py", line 87, in read_next_frame
    frame = self.capture.read_frame()
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/inputs/input.py", line 188, in read_frame
    img = self._read_frame_func()
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/inputs/opencv_file.py", line 87, in _read_frame_func
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/engine.py", line 63, in call_plugins
    getattr(op, event_name)(self.context)
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/outputs/statink.py", line 652, in on_game_session_end
    payload = self.composite_payload(context)
  File "/Users/deathmetalland/Workspace/IkaLog/ikalog/outputs/statink.py", line 438, in composite_payload
    index = fes_rank_titles.index(current_title)
ValueError: 'friend' is not in list

<<<<<
```

https://github.com/hasegaw/IkaLog/commit/7b39be21671828fb9aea56ea7e101fab49b384f5 にあわせて friend -> fiend に変更しました。

Signed-off-by: Death <deathmetalland@gmail.com>