### PR TITLE
Created IkaUtils.death_reason2text and related unittests.

### DIFF
--- a/ikalog/outputs/commentator.py
+++ b/ikalog/outputs/commentator.py
@@ -256,15 +256,8 @@ class Commentator(object):
     def _death_reason_label(self, reason):
         if reason in self.custom_read:
             return self.custom_read[reason]
-        if reason in weapons:
-            return weapons[reason]['ja']
-        if reason in sub_weapons:
-            return sub_weapons[reason]['ja']
-        if reason in special_weapons:
-            return special_weapons[reason]['ja']
-        if reason in hurtable_objects:
-            return hurtable_objects[reason]['ja']
-        return self.custom_read['unknown']
+        return IkaUtils.death_reason2text(
+            reason, self.custom_read['unknown'], 'ja')
 
     def on_game_finish(self, context):
         self._read_event('finish')

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -29,6 +29,8 @@ import numpy as np
 from PIL import Image
 
 from ikalog.constants import stages, rules, gear_abilities
+# Constants for death_reason2text
+from ikalog.constants import hurtable_objects, oob_reasons, special_weapons, sub_weapons, weapons
 from ikalog.utils.localization import Localization
 from ikalog.utils import imread
 
@@ -167,6 +169,26 @@ class IkaUtils(object):
 
         # Should not reach here
         return gear_ability_id
+
+    @staticmethod
+    def death_reason2text(reason, unknown='?', languages=None):
+        reason_dict = {}
+        if reason in weapons:
+            reason_dict = weapons[reason]
+        if reason in sub_weapons:
+            reason_dict = sub_weapons[reason]
+        if reason in special_weapons:
+            reason_dict = special_weapons[reason]
+        if reason in oob_reasons:
+            reason_dict = oob_reasons[reason]
+        if reason in hurtable_objects:
+            reason_dict = hurtable_objects[reason]
+
+        for lang in IkaUtils.extend_languages(languages):
+            if lang in reason_dict:
+                return reason_dict[lang]
+
+        return unknown
 
     @staticmethod
     def cropImageGray(img, left, top, width, height):

--- a/test/outputs/test_commentator.py
+++ b/test/outputs/test_commentator.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  IkaLog
+#  ======
+#  Copyright (C) 2015 Takeshi HASEGAWA
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#  Unittests for commentator.py.
+#  Usage:
+#    python ./test_commentator.py
+#  or
+#    py.test ./test_commentator.py
+
+import unittest
+import os.path
+import sys
+
+# Append the Ikalog root dir to sys.path to import Commentator.
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from ikalog.outputs.commentator import Commentator
+
+class TestIkaUtils(unittest.TestCase):
+    def test__death_reason_label(self):
+        # _death_reason_lable is only for Japanese at this moment.
+        commentator = Commentator()
+        # Custom read
+        self.assertEqual('ごーにーガロン',
+                         commentator._death_reason_label('52gal'))
+        # Weapons
+        self.assertEqual('わかばシューター',
+                         commentator._death_reason_label('wakaba'))
+        # Sub weapons
+        self.assertEqual('チェイスボム',
+                         commentator._death_reason_label('chasebomb'))
+        # Special weapons
+        self.assertEqual('トルネード',
+                         commentator._death_reason_label('tornado'))
+        # Hurtable objects
+        self.assertEqual('プロペラから飛び散ったインク',
+                         commentator._death_reason_label('propeller'))
+
+        # OOB is treated in a different function.
+
+        # Unknown
+        self.assertEqual('未知の武器',
+                         commentator._death_reason_label('530000gal'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -140,5 +140,61 @@ class TestIkaUtils(unittest.TestCase):
                                                     unknown='<:='))
 
 
+    def test_death_reason2text(self):
+        ### Weapons
+        reason = 'hokusai'
+
+        # English
+        self.assertEqual('Octobrush',
+                         IkaUtils.death_reason2text(reason, languages='en'))
+
+        # Japanese
+        self.assertEqual('ホクサイ',
+                         IkaUtils.death_reason2text(reason, languages='ja'))
+
+        # Fallback to English
+        self.assertEqual('Octobrush',
+                         IkaUtils.death_reason2text(reason, languages='??'))
+
+        # Multiple languages
+        self.assertEqual('ホクサイ',
+                         IkaUtils.death_reason2text(reason,
+                                                    languages=['ja', 'en']))
+
+        ### Sub weapons
+        reason = 'trap'
+        self.assertEqual('Ink Mine',
+                         IkaUtils.death_reason2text(reason, languages='en'))
+        self.assertEqual('トラップ',
+                         IkaUtils.death_reason2text(reason, languages='ja'))
+
+        ### Special weapons
+        reason = 'daioika'
+        self.assertEqual('Kraken',
+                         IkaUtils.death_reason2text(reason, languages='en'))
+        self.assertEqual('ダイオウイカ',
+                         IkaUtils.death_reason2text(reason, languages='ja'))
+
+        ### Hurtable objects
+        reason = 'hoko_shot'
+        self.assertEqual('Rainmaker Shot',
+                         IkaUtils.death_reason2text(reason, languages='en'))
+        self.assertEqual('ガチホコショット',
+                         IkaUtils.death_reason2text(reason, languages='ja'))
+
+        ### OOB reasons
+        reason = 'oob'
+        self.assertEqual('Out of Bounds',
+                         IkaUtils.death_reason2text(reason, languages='en'))
+        self.assertEqual('場外',
+                         IkaUtils.death_reason2text(reason, languages='ja'))
+
+        ### Unkonwn
+        unknown_reason = 'unknown'
+        self.assertEqual('?', IkaUtils.death_reason2text(unknown_reason))
+        self.assertEqual('<:=',
+                         IkaUtils.death_reason2text(unknown_reason,
+                                                    unknown='<:='))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Created death_reason2text which converts a reason string to localized message.
* Added unittests for death_reason2text.
* Modified outputs/commentator.py to use death_reason2text.
* Created test_commentator.py to check the modified code.