### PR TITLE
Changed the type of argument of IkaUtils.gear_ability2text.

### DIFF
--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -147,23 +147,15 @@ class IkaUtils(object):
         return rule_id
 
     @staticmethod
-    def gear_ability2id(gear_ability, unknown='?'):
+    def gear_ability2text(gear_ability, unknown='?', languages=None):
         if gear_ability is None:
             return unknown
-        return gear_ability.id_
 
-    @staticmethod
-    def gear_ability2text(gear_ability, unknown='?', languages=None):
-        gear_ability_id = IkaUtils.gear_ability2id(gear_ability, unknown=None)
-
-        if gear_ability_id is None:
-            return unknown
-
-        if gear_abilities.get(gear_ability_id, None) is None:
+        if gear_abilities.get(gear_ability, None) is None:
             return unknown
 
         for lang in IkaUtils.extend_languages(languages):
-            gear_ability_text = gear_abilities[gear_ability_id].get(lang, None)
+            gear_ability_text = gear_abilities[gear_ability].get(lang, None)
             if gear_ability_text is not None:
                 return gear_ability_text
 

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -113,30 +113,30 @@ class TestIkaUtils(unittest.TestCase):
 
 
     def test_gear_ability2text(self):
-        gear_mock = IkaMatcherMock('ninja_squid')
+        gear = 'ninja_squid'
 
         # English
         self.assertEqual('Ninja Squid',
-                         IkaUtils.gear_ability2text(gear_mock, languages='en'))
+                         IkaUtils.gear_ability2text(gear, languages='en'))
 
         # Japanese
         self.assertEqual('イカニンジャ',
-                         IkaUtils.gear_ability2text(gear_mock, languages='ja'))
+                         IkaUtils.gear_ability2text(gear, languages='ja'))
 
         # Fallback to English
         self.assertEqual('Ninja Squid',
-                         IkaUtils.gear_ability2text(gear_mock, languages='??'))
+                         IkaUtils.gear_ability2text(gear, languages='??'))
 
         # Multiple languages
         self.assertEqual('イカニンジャ',
-                         IkaUtils.gear_ability2text(gear_mock,
+                         IkaUtils.gear_ability2text(gear,
                                                     languages=['ja', 'en']))
 
         # Unkonwn
-        unknown_gear_mock = IkaMatcherMock('unknown')
-        self.assertEqual('?', IkaUtils.gear_ability2text(unknown_gear_mock))
+        unknown_gear = 'unknown'
+        self.assertEqual('?', IkaUtils.gear_ability2text(unknown_gear))
         self.assertEqual('<:=',
-                         IkaUtils.gear_ability2text(unknown_gear_mock,
+                         IkaUtils.gear_ability2text(unknown_gear,
                                                     unknown='<:='))
 
 


### PR DESCRIPTION
* gear_ability2id or gear_ability2text is not used anywhere.
* As IkaMatcher does not contain gear_ability, the argument of
  gear_ability2text should not be an IkaMatcher instance, but a str.
* Removed gear_ability2id. This is unnecessary.
* Updated related unittests.