### PR TITLE
scenes/lobby: Fixed on_lobby_matched event fired on game end.

### DIFF
--- a/ikalog/scenes/lobby.py
+++ b/ikalog/scenes/lobby.py
@@ -128,7 +128,7 @@ class Lobby(Scene):
             if matched:
                 match_count = match_count + 1
 
-        if match_count > 1:
+        if match_count != 1:
             return False
 
         # フェスの場合


### PR DESCRIPTION
match_public_lobby() がどのイメージともマッチしない場合にTrueを返していたため、
試合終了時の変なタイミングで on_lobby_matched イベントが発火する場合があったのを修正しました。

Signed-off-by: syptn <greenneon.amaebi@gmail.com>