### PR TITLE
Added a concept of the epoch_time in the video and utilities.

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -140,6 +140,7 @@ class IkaEngine:
     def create_context(self):
         self.context = {
             'engine': {
+                'epoch_time': None,
                 'frame': None,
                 'service': {
                     'call_plugins': self.call_plugins,
@@ -272,6 +273,9 @@ class IkaEngine:
     def set_capture(self, capture):
         self.capture = capture
         self.context['engine']['input_class'] = self.capture.__class__.__name__
+
+    def set_epoch_time(self, epoch_time):
+        self.context['engine']['epoch_time'] = epoch_time
 
     def set_plugins(self, plugins):
         self.output_plugins = [self]

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -23,6 +23,7 @@ import os
 import platform
 import re
 import sys
+import time
 
 import cv2
 import numpy as np
@@ -253,3 +254,12 @@ class IkaUtils(object):
             self.dprint("Screenshot: failed")
             return False
         return True
+
+    @staticmethod
+    def getTime(context):
+        """Returns the current time in sec considering the epoch time."""
+        epoch_time = context['engine']['epoch_time']
+        if epoch_time is None:
+            return time.time()
+        time_sec = context['engine']['msec'] / 1000.0
+        return epoch_time + time_sec

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -27,6 +27,7 @@
 import unittest
 import os.path
 import sys
+import time
 
 # Append the Ikalog root dir to sys.path to import IkaUtils.
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -195,6 +196,31 @@ class TestIkaUtils(unittest.TestCase):
         self.assertEqual('<:=',
                          IkaUtils.death_reason2text(unknown_reason,
                                                     unknown='<:='))
+
+
+    def test_get_time(self):
+        mock_context = {'engine': {'epoch_time': None, 'msec': 5000}}
+
+        # epoch_time is None
+        time_before = time.time()
+        time_actual = IkaUtils.getTime(mock_context)
+        time_after = time.time()
+        self.assertTrue(time_before <= time_actual <= time_after)
+
+        # epoch_time is 0
+        mock_context['engine']['epoch_time'] = 0
+        expected_time = (mock_context['engine']['epoch_time'] +
+                         mock_context['engine']['msec'] / 1000.0)
+        self.assertEqual(expected_time, IkaUtils.getTime(mock_context))
+
+        # epoch_time is 2015-05-28 10:00:00, msec is 1 hour
+        mock_context['engine']['epoch_time'] = (
+            time.mktime(time.strptime("20150528_100000", "%Y%m%d_%H%M%S")))
+        mock_context['engine']['msec'] = 60 * 60 * 1000
+        time_actual = IkaUtils.getTime(mock_context)
+        self.assertEqual("20150528_110000",
+                         time.strftime("%Y%m%d_%H%M%S",
+                                       time.localtime(time_actual)))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Added context['engine']['epoch_time'] and its accessor.
  The value is in sec.
* Added IkaUtils.getTime. If epoch_time is specified,
  it returns the current time since the epoch time.
  If not specified, the time in the real world is returned.

----
This is one of a series of my several pull requests.

The goal is to enable to specify the actual start and end times to stat.ink. The current implementation sends the time of IkaLog.py worked, but sending the actual game time might be better.

The whole change to achieve it is here:
hiroyuki-komatsu@c686f85

Here's a sample result:
https://stat.ink/u/hirok_dev/1065469