### PR TITLE
Enabled to specify the epoch time of the video.

### DIFF
--- a/IkaLog.py
+++ b/IkaLog.py
@@ -23,6 +23,7 @@ Localization.print_language_settings()
 
 import argparse
 import signal
+import time
 from ikalog.engine import *
 from IkaConfig import *
 from ikalog.utils import *
@@ -43,6 +44,8 @@ def get_args():
                         default=False)
     parser.add_argument('--time', '-t', dest='time', type=str)
     parser.add_argument('--time_msec', dest='time_msec', type=int)
+    parser.add_argument('--epoch_time', dest='epoch_time', type=str,
+                        help='In the format like 20150528_235900 or "now".')
     parser.add_argument('--video_id', dest='video_id', type=str)
 
     return vars(parser.parse_args())
@@ -50,6 +53,17 @@ def get_args():
 def time_to_msec(time):
     minute, sec = time.split(':')
     return (int(minute) * 60 + int(sec)) * 1000
+
+def get_epoch_time(args, capture):
+    """Returns the epoch time in sec or None."""
+    epoch_time_arg = args.get('epoch_time')
+    if epoch_time_arg == 'now':
+        return None
+
+    if not epoch_time_arg:
+        return None
+
+    return time.mktime(time.strptime(epoch_time_arg, "%Y%m%d_%H%M%S"))
 
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
@@ -65,6 +79,11 @@ if __name__ == "__main__":
     engine = IkaEngine(enable_profile=args.get('profile'))
     engine.pause(False)
     engine.set_capture(capture)
+
+    epoch_time = get_epoch_time(args, capture)
+    if epoch_time:
+        engine.set_epoch_time(epoch_time)
+
     engine.set_plugins(OutputPlugins)
     engine.close_session_at_eof = True
     engine.run()

--- a/ikalog/outputs/screenshot.py
+++ b/ikalog/outputs/screenshot.py
@@ -115,7 +115,8 @@ class Screenshot(object):
 
         drawing = context['engine']['frame'][y1:y2, x1:x2, :]
 
-        timestr = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+        timestr = time.strftime("%Y%m%d_%H%M%S",
+                                time.localtime(IkaUtils.getTime(context)))
         destfile = os.path.join(self.dir, 'miiverse_%s.png' % timestr)
 
         IkaUtils.writeScreenshot(destfile, drawing)
@@ -127,7 +128,8 @@ class Screenshot(object):
     # @param context   IkaLog context
     #
     def on_result_detail_still(self, context):
-        timestr = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+        timestr = time.strftime("%Y%m%d_%H%M%S",
+                                time.localtime(IkaUtils.getTime(context)))
         destfile = os.path.join(self.dir, 'ikabattle_%s.png' % timestr)
 
         IkaUtils.writeScreenshot(destfile, context['engine']['frame'])

--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -661,7 +661,7 @@ class StatInk(object):
         pprint.pprint(payload)
 
     def on_game_go_sign(self, context):
-        self.time_start_at = int(time.time())
+        self.time_start_at = int(IkaUtils.getTime(context))
         self.time_end_at = None
         self.events = []
         self.time_last_score_msec = None
@@ -679,7 +679,7 @@ class StatInk(object):
         self.on_game_go_sign(context)
 
     def on_game_finish(self, context):
-        self.time_end_at = int(time.time())
+        self.time_end_at = int(IkaUtils.getTime(context))
         if ('msec' in context['engine']) and (self.time_start_at_msec is not None):
             duration_msec = context['engine']['msec'] - self.time_start_at_msec
 


### PR DESCRIPTION
* Added --epoch_time flag. The format is 20150528_235900 or "now".
* Made Screenshot and StatInk to consider the epoch time.

----
This is one of a series of my several pull requests.

The goal is to enable to specify the actual start and end times to stat.ink. The current implementation sends the time of IkaLog.py worked, but sending the actual game time might be better.

The whole change to achieve it is here:
hiroyuki-komatsu@c686f85

Here's a sample result:
https://stat.ink/u/hirok_dev/1065469