### PR TITLE
Changed to use the last modified time of the video file as the epoch time

### DIFF
--- a/IkaLog.py
+++ b/IkaLog.py
@@ -61,6 +61,8 @@ def get_epoch_time(args, capture):
         return None
 
     if not epoch_time_arg:
+        if isinstance(capture, inputs.CVFile):
+            return capture.get_start_time()
         return None
 
     return time.mktime(time.strptime(epoch_time_arg, "%Y%m%d_%H%M%S"))

--- a/ikalog/inputs/opencv_file.py
+++ b/ikalog/inputs/opencv_file.py
@@ -61,6 +61,7 @@ class CVFile(VideoInput):
             self.reset()
             # FIXME: Does it work with non-ascii path?
             self.video_capture = cv2.VideoCapture(source)
+            self._source_file = source
             if not self.video_capture.isOpened:
                 self.video_capture = None
             self.reset_tick()
@@ -103,6 +104,16 @@ class CVFile(VideoInput):
                 skip = video_msec < systime_msec
 
         return frame
+
+    def get_start_time(self):
+        """Returns the timestamp of the beginning of this video in sec."""
+        last_modified_time = os.stat(self._source_file).st_mtime
+
+        frames = self.video_capture.get(cv2.CAP_PROP_FRAME_COUNT)
+        fps = self.video_capture.get(cv2.CAP_PROP_FPS)
+        duration = frames / fps
+
+        return last_modified_time - duration
 
     def set_pos_msec(self, pos_msec):
         """Moves the video position to |pos_msec| in msec."""


### PR DESCRIPTION
CAVEAT: It changes the default behavior when the input is a video file.

* Added CVFile.get_start_time which returns the beginning time of the video.
* Added CVFile._source_file, a string value of the source file path.
* Changed to use CVFile.get_start_time to set the default epoch time.

----
This is the last one of a series of my several pull requests :)

The goal is to enable to specify the actual start and end times to stat.ink. The current implementation sends the time of IkaLog.py worked, but sending the actual game time might be better.

The whole change to achieve it is here:
hiroyuki-komatsu@c686f85

Here's a sample result:
https://stat.ink/u/hirok_dev/1065469