### PR TITLE
hanged the output format StatInk.write_payload_to_file

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -551,14 +551,14 @@ class StatInk(object):
             IkaUtils.dprint('%s: Failed to write file' % self)
             IkaUtils.dprint(traceback.format_exc())
 
-    def write_payload_to_file(self, payload, basename=None):
-        if basename is None:
+    def write_payload_to_file(self, payload, filename=None):
+        if filename is None:
             t = datetime.now().strftime("%Y%m%d_%H%M")
-            basename = os.path.join('/tmp', 'statink_%s' % t)
+            filename = os.path.join('/tmp', 'statink_%s.msgpack' % t)
 
         try:
-            f = open(basename + '.msgpack', 'w')
-            f.write(''.join(map(chr, umsgpack.packb(payload))))
+            f = open(filename, 'wb')
+            umsgpack.pack(payload, f)
             f.close()
         except:
             IkaUtils.dprint('%s: Failed to write msgpack file' % self)


### PR DESCRIPTION
CAVEAT: This changes write_payload_to_file w/o backward compatibility.

* Changed the format from chr-mapped msgpack to plain msgpack
* Enabled to specify any filename for the output.

----
This is one of PR requests to create a command line tool to upload
a stat.ink payload to the server.

After these changes, we will be able to do 2 pass process:
1. analysis of the video and save a stat.ink payload file.
2. upload the payload file anytime.

Here's the whole changes to be requested so far.
https://github.com/hiroyuki-komatsu/IkaLog/commits/statink