### PR TITLE
Added --statink_payload flag.

### DIFF
--- a/IkaConfig.py.sample
+++ b/IkaConfig.py.sample
@@ -152,6 +152,7 @@ OUTPUT_ARGS['StatInk'] = {
     'track_objective': False,
     'track_inklings': False,
     'video_id': None,
+    'payload_file': None,
 }
 
 # Twitter: Twitter 連携
@@ -200,4 +201,3 @@ OUTPUT_ARGS['DebugVideoWriter'] = {'dir': './debug_videos/'}
 #
 # OUTPUT_PLUGINS.append('PreviewDetected')
 OUTPUT_ARGS['PreviewDetected'] = {}
-

--- a/IkaLog.py
+++ b/IkaLog.py
@@ -44,6 +44,10 @@ def get_args():
     parser.add_argument('--input_file', '-f', dest='input_file', type=str)
     parser.add_argument('--output_description', '--desc',
                         dest='output_description', type=str)
+    parser.add_argument('--statink_payload',
+                        dest='statink_payload', type=str,
+                        help='Payload file to stat.ink. '
+                        'If this is specified, the data is not uploaded.')
     parser.add_argument('--profile', dest='profile', action='store_true',
                         default=False)
     parser.add_argument('--time', '-t', dest='time', type=str)

--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -605,6 +605,12 @@ class StatInk(object):
                 '%s: Dry-run mode, skipping POST to stat.ink.' % self)
             return
 
+        if self.payload_file:
+            IkaUtils.dprint(
+                '%s: payload_file is specified to %s, '
+                'skipping POST to stat.ink.' % (self, self.payload_file))
+            return
+
         if api_key is None:
             api_key = self.api_key
 
@@ -692,8 +698,8 @@ class StatInk(object):
 
         self.print_payload(payload)
 
-        if self.debug_writePayloadToFile:
-            self.write_payload_to_file(payload)
+        if self.debug_writePayloadToFile or self.payload_file:
+            self.write_payload_to_file(payload, filename=self.payload_file)
 
         self.post_payload(context, payload)
 
@@ -846,7 +852,11 @@ class StatInk(object):
     def on_game_ranked_they_lead(self, context):
         self._add_ranked_battle_event(context, 'they_lead')
 
-    def __init__(self, api_key=None, track_objective=False, track_splatzone=False, track_inklings=False, track_special_gauge=False, track_special_weapon=False, debug=False, dry_run=False, url='https://stat.ink', video_id=None):
+    def __init__(self, api_key=None, track_objective=False,
+                 track_splatzone=False, track_inklings=False,
+                 track_special_gauge=False, track_special_weapon=False,
+                 debug=False, dry_run=False, url='https://stat.ink',
+                 video_id=None, payload_file=None):
         self.enabled = not (api_key is None)
         self.api_key = api_key
         self.dry_run = dry_run
@@ -875,6 +885,7 @@ class StatInk(object):
         self.url_statink_v1_battle = '%s/api/v1/battle' % url
 
         self.video_id = video_id
+        self.payload_file = payload_file
 
 if __name__ == "__main__":
     # main として呼ばれた場合

--- a/ikalog/utils/config_loader.py
+++ b/ikalog/utils/config_loader.py
@@ -135,6 +135,8 @@ def _init_outputs(opts):
     if 'StatInk' in output_plugins:
         if opts.get('video_id'):
             output_args['StatInk']['video_id'] = opts['video_id']
+        if opts.get('statink_payload'):
+            output_args['StatInk']['payload_file'] = opts['statink_payload']
 
         OutputPlugins.append(outputs.StatInk(**output_args['StatInk']))
 


### PR DESCRIPTION
* This flag specifies a file path to store a payload of stat.ink result.
* If this flag is specified the payload is not uploaded to stat.ink.

----
This is one of PR requests to create a command line tool to upload
a stat.ink payload to the server.

After these changes, we will be able to do 2 pass process:
1. analysis of the video and save a stat.ink payload file.
2. upload the payload file anytime.

Here's the whole changes to be requested so far.
https://github.com/hiroyuki-komatsu/IkaLog/commits/statink