### PR TITLE
Added tools/statink/upload_payload.py command.

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -568,8 +568,8 @@ class StatInk(object):
         # This function runs on worker thread.
 
         error, statink_response = UploadToStatInk(payload,
-                                                  self.url_statink_v1_battle,
                                                   api_key,
+                                                  self.url_statink_v1_battle,
                                                   self.show_response_enabled,
                                                   (self.dry_run == 'server'))
 

--- a/ikalog/utils/statink_uploader.py
+++ b/ikalog/utils/statink_uploader.py
@@ -28,9 +28,11 @@ import urllib3
 from ikalog.utils import *
 
 
-def UploadToStatInk(payload, url, api_key, video_id=None,
+def UploadToStatInk(payload, api_key, url=None, video_id=None,
                     show_response=False, dry_run=False):
     name = 'UploadToStatInk'
+    if not url:
+        url = 'https://stat.ink/api/v1/battle'
 
     # Payload data will be modified, so we copy it.
     # It is not deep copy, so only dict object is duplicated.

--- a/tools/statink/upload_payload.py
+++ b/tools/statink/upload_payload.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  IkaLog
+#  ======
+#  Copyright (C) 2016 Takeshi HASEGAWA
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import argparse
+import os
+import sys
+import umsgpack
+
+# Append the Ikalog root dir to sys.path to import IkaUtils.
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+import IkaConfig
+from ikalog.utils.statink_uploader import UploadToStatInk
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--payload', dest='payload', type=str)
+    parser.add_argument('--api_key', dest='api_key', type=str)
+    parser.add_argument('--video_id', dest='video_id', type=str)
+
+    return vars(parser.parse_args())
+
+
+def main():
+    args = get_args()
+    f = open(args['payload'], 'rb')
+    payload = umsgpack.unpack(f)
+    f.close()
+    url = 'https://stat.ink/api/v1/battle'
+    api_key = (args['api_key'] or IkaConfig.OUTPUT_ARGS['StatInk']['api_key'])
+    error, response = UploadToStatInk(payload, api_key, url, args['video_id'])
+    print(response.get('url'))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is the last one of the series of PRs.

Usage:
./IkaLog.py -f video.mp4 --statink_payload statink.msgpack
./tools/statink/upload_payload.py --payload statink.msgpack --video_id VIDEOID

* Changed the order of the arguments of statink_uploader.UploadToStatInk.

----
This is one of PR requests to create a command line tool to upload
a stat.ink payload to the server.

After these changes, we will be able to do 2 pass process:
1. analysis of the video and save a stat.ink payload file.
2. upload the payload file anytime.

Here's the whole changes to be requested so far.
https://github.com/hiroyuki-komatsu/IkaLog/commits/statink