### PR TITLE
Fix KeyError when the first read_next_frame fails

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -220,7 +220,7 @@ class IkaEngine:
             # end_time should be initialized in GameFinish or session_close.
             # This is a fallback in case they were skipped.
             self.context['game']['end_time'] = IkaUtils.getTime(self.context)
-            self.context['game']['end_offset_msec'] = self.context['engine']['msec']
+            self.context['game']['end_offset_msec'] = self.context['engine'].get('msec', None)
 
         self.call_plugins('on_game_session_abort')
         self.reset()


### PR DESCRIPTION
```
% python IkaLog.py
IkaLog Primary CLI Language: en_US.UTF-8 (set LANG to override)
IkaLog Game Language: ja (set IKALOG_LANG to override)
<ikalog.utils.icon_recoginizer.weapon.WeaponRecoginizer object at 0x7f76a50e00b8>: KNN Trained (8118 samples)
<ikalog.utils.icon_recoginizer.gearpower.GearPowerRecoginizer object at 0x7f76a50e0128>: KNN Trained (1010 samples)
<ikalog.inputs.filters.warp_model.WarpFilterModel object at 0x7f76a1771cc0>: Loaded model data
  /home/eagletmt/.ghq/github.com/hasegaw/IkaLog/data/webcam_calibration.ja.model (3010 keypoints)
(ERROR)icvOpenAVI_XINE(): Unable to open source 'videotestsrc ! videoconvert ! appsink'
Traceback (most recent call last):
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 307, in _main_loop
    self.process_frame()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 256, in process_frame
    frame, t = self.read_next_frame()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 129, in read_next_frame
    frame = self.capture.read_frame()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/inputs/input.py", line 188, in read_frame
    img = self._read_frame_func()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/inputs/opencv_file.py", line 88, in _read_frame_func
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "IkaLog.py", line 108, in <module>
    engine.run()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 323, in run
    self._main_loop()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 315, in _main_loop
    self.session_abort()
  File "/home/eagletmt/.ghq/github.com/hasegaw/IkaLog/ikalog/engine.py", line 223, in session_abort
    self.context['game']['end_offset_msec'] = self.context['engine']['msec']
KeyError: 'msec'
```