### PR TITLE
Use `context['game']['end_time']` as timestamps

### DIFF
--- a/ikalog/outputs/console.py
+++ b/ikalog/outputs/console.py
@@ -122,9 +122,6 @@ class Console(object):
             lose_text=_('lose'),
             unknown_text=_('unknown'),
         )
-        t = datetime.now()
-        t_str = t.strftime("%Y,%m,%d,%H,%M")
-        t_unix = int(time.mktime(t.timetuple()))
         me = IkaUtils.getMyEntryFromContext(context)
 
         s = _('Results. Stage: %(stage)s, Mode: %(rule)s, Result: %(result)s') % \

--- a/ikalog/outputs/csv.py
+++ b/ikalog/outputs/csv.py
@@ -18,7 +18,6 @@
 #  limitations under the License.
 #
 
-from datetime import datetime
 import os
 import time
 
@@ -121,9 +120,9 @@ class CSV(object):
         won = IkaUtils.getWinLoseText(
             context['game']['won'], win_text="勝ち", lose_text="負け", unknown_text="不明")
 
-        t = context['game']['end_time']
+        t = IkaUtils.get_end_time(context)
         t_unix = int(t)
-        t_str = datetime.fromtimestamp(t).strftime("%Y,%m,%d,%H,%M")
+        t_str = t.strftime("%Y,%m,%d,%H,%M")
         s_won = IkaUtils.getWinLoseText(
             won, win_text="勝ち", lose_text="負け", unknown_text="不明")
 

--- a/ikalog/outputs/csv.py
+++ b/ikalog/outputs/csv.py
@@ -121,9 +121,9 @@ class CSV(object):
         won = IkaUtils.getWinLoseText(
             context['game']['won'], win_text="勝ち", lose_text="負け", unknown_text="不明")
 
-        t = datetime.now()
-        t_str = t.strftime("%Y,%m,%d,%H,%M")
-        t_unix = int(time.mktime(t.timetuple()))
+        t = context['game']['end_time']
+        t_unix = int(t)
+        t_str = datetime.fromtimestamp(t).strftime("%Y,%m,%d,%H,%M")
         s_won = IkaUtils.getWinLoseText(
             won, win_text="勝ち", lose_text="負け", unknown_text="不明")
 

--- a/ikalog/outputs/printjson.py
+++ b/ikalog/outputs/printjson.py
@@ -120,9 +120,7 @@ class JSON(object):
         won = IkaUtils.getWinLoseText(
             context['game']['won'], win_text="win", lose_text="lose", unknown_text="unknown")
 
-        t = datetime.now()
-        t_str = t.strftime("%Y,%m,%d,%H,%M")
-        t_unix = int(time.mktime(t.timetuple()))
+        t_unix = int(context['game']['end_time'])
 
         record = {
             'time': t_unix,

--- a/ikalog/outputs/printjson.py
+++ b/ikalog/outputs/printjson.py
@@ -18,7 +18,6 @@
 #  limitations under the License.
 #
 
-from datetime import datetime
 import json
 import os
 import time
@@ -120,7 +119,7 @@ class JSON(object):
         won = IkaUtils.getWinLoseText(
             context['game']['won'], win_text="win", lose_text="lose", unknown_text="unknown")
 
-        t_unix = int(context['game']['end_time'])
+        t_unix = int(IkaUtils.get_end_time(context))
 
         record = {
             'time': t_unix,

--- a/ikalog/outputs/twitter.py
+++ b/ikalog/outputs/twitter.py
@@ -21,7 +21,6 @@
 # @package IkaOutput_Twitter
 
 import os
-from datetime import datetime
 import json
 
 import cv2
@@ -473,7 +472,7 @@ class Twitter(object):
             lose_text=_('lost'),
             unknown_text=_('played'))
 
-        t = datetime.fromtimestamp(context['game']['end_time']).strftime("%Y/%m/%d %H:%M")
+        t = IkaUtils.get_end_time(context).strftime("%Y/%m/%d %H:%M")
 
         s = _('Just %(result)s %(rule)s at %(stage)s') % \
             { 'stage': stage, 'rule': rule, 'result': result}

--- a/ikalog/outputs/twitter.py
+++ b/ikalog/outputs/twitter.py
@@ -473,7 +473,7 @@ class Twitter(object):
             lose_text=_('lost'),
             unknown_text=_('played'))
 
-        t = datetime.now().strftime("%Y/%m/%d %H:%M")
+        t = datetime.fromtimestamp(context['game']['end_time']).strftime("%Y/%m/%d %H:%M")
 
         s = _('Just %(result)s %(rule)s at %(stage)s') % \
             { 'stage': stage, 'rule': rule, 'result': result}

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -24,6 +24,7 @@ import platform
 import re
 import sys
 import time
+from datetime import datetime
 
 import cv2
 import numpy as np
@@ -265,3 +266,11 @@ class IkaUtils(object):
             return time.time()
         time_sec = context['engine']['msec'] / 1000.0
         return epoch_time + time_sec
+
+    @staticmethod
+    def get_end_time(context):
+        unix_time = context['game'].get('end_time')
+        if unix_time:
+            return datetime.fromtimestamp(unix_time)
+        else:
+            return datetime.now()


### PR DESCRIPTION
For non-realtime input (i.e. CVFile), using
`context['game']['end_time']` is better, I think, than `datetime.now()`.