### PR TITLE
Enabled to handle multiple games from a file w/ --statink_payload flag.

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -726,6 +726,12 @@ class StatInk(object):
         IkaUtils.dprint('%s: Gathered img_judge(%s)' %
                         (self, self.img_judge.shape))
 
+    def _get_payload_file(self, payload_file, index):
+        if not payload_file or index == 0:
+            return payload_file
+        base, ext = os.path.splitext(payload_file)
+        return '%s-%d%s' % (base, index, ext)
+
     def _close_game_session(self, context):
         if self._called_close_game_session:
             return
@@ -741,7 +747,9 @@ class StatInk(object):
         self.print_payload(payload)
 
         if self.debug_writePayloadToFile or self.payload_file:
-            self.write_payload_to_file(payload, filename=self.payload_file)
+            payload_file = self._get_payload_file(self.payload_file,
+                                                  context['game']['index'])
+            self.write_payload_to_file(payload, filename=payload_file)
 
         self.post_payload(context, payload)
 

--- a/test/outputs/test_statink.py
+++ b/test/outputs/test_statink.py
@@ -25,19 +25,15 @@ import sys
 # Append the Ikalog root dir to sys.path to import IkaUtils.
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from ikalog import constants
+from ikalog.outputs.statink import StatInk
 
 class IkaMatcherMock(object):
     def __init__(self, id):
         self.id_ = id
 
 class TestStatInk(unittest.TestCase):
-
-    def _load_StatInk(self):
-        from ikalog.outputs.statink import StatInk
-        return StatInk('not_valid_key')
-
     def test_composite(self):
-        statink = self._load_StatInk()
+        statink = StatInk()
 
         context = {
             'game': {
@@ -158,6 +154,18 @@ class TestStatInk(unittest.TestCase):
         assert payload['his_team_color']['hue'] == 160 * 2
 
         # TODO: Test RGB data
+
+    def test__get_payload_file(self):
+        statink = StatInk()
+        self.assertIsNone(statink._get_payload_file(None, 0))
+        self.assertEqual('/tmp/statink.msgpack',
+                         statink._get_payload_file('/tmp/statink.msgpack', 0))
+        self.assertEqual('/tmp/statink-1.msgpack',
+                         statink._get_payload_file('/tmp/statink.msgpack', 1))
+        self.assertEqual('/tmp/statink-10.msgpack',
+                         statink._get_payload_file('/tmp/statink.msgpack', 10))
+        self.assertEqual('/tmp/video.mp4-1.statink',
+                         statink._get_payload_file('/tmp/video.mp4.statink', 1))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There was a problem when:
* --statink_payload is specified, and
* --input_file is also specified and it contains multiple games.

In the above case, only the last game was saved to the file.
With this change, the games are saved as follows:

1st game: statink.msgpack
2nd game: statink-1.msgpack
3rd game: statink-2.msgpack
...