### PR TITLE
tools/statink/upload_payload.py: Parser updates.

### DIFF
--- a/tools/statink/upload_payload.py
+++ b/tools/statink/upload_payload.py
@@ -21,19 +21,27 @@
 import argparse
 import os
 import sys
+
 import umsgpack
 
 # Append the Ikalog root dir to sys.path to import IkaUtils.
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
-import IkaConfig
 from ikalog.utils.statink_uploader import UploadToStatInk
 
 
 def get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--payload', dest='payload', type=str)
-    parser.add_argument('--api_key', dest='api_key', type=str)
-    parser.add_argument('--video_id', dest='video_id', type=str)
+    parser = argparse.ArgumentParser(
+        description='Post stat.ink payload to the server.'
+    )
+
+    parser.add_argument(
+        dest='payload', metavar='STATINK_PAYLOAD_FILE', type=str)
+    parser.add_argument(
+        '--api_key', dest='api_key', metavar='YOUR_API_KEY', type=str)
+    parser.add_argument(
+        '--video_id', dest='video_id', metavar='YOUTUBE_VIDEO_ID', type=str)
+    parser.add_argument(
+        '--endpoint', dest='endpoint', metavar='API_ENDPOINT_URL', type=str)
 
     return vars(parser.parse_args())
 
@@ -43,8 +51,14 @@ def main():
     f = open(args['payload'], 'rb')
     payload = umsgpack.unpack(f)
     f.close()
-    url = 'https://stat.ink/api/v1/battle'
-    api_key = (args['api_key'] or IkaConfig.OUTPUT_ARGS['StatInk']['api_key'])
+
+    url = args['endpoint'] or 'https://stat.ink/api/v1/battle'
+
+    api_key = args['api_key']
+    if not api_key:
+        import IkaConfig
+        api_key = IkaConfig.OUTPUT_ARGS['StatInk']['api_key']
+
     error, response = UploadToStatInk(payload, api_key, url, args['video_id'])
     print(response.get('url'))
 


### PR DESCRIPTION
* Add endpoint option.
* Remove --payload option. arg('payload') is now the primary argument.
* Remove IkaConfig import.

```
dhcp44-80:IkaLog_github12 hasegaw$ python3 tools/statink/upload_payload.py
usage: upload_payload.py [-h] [--api_key YOUR_API_KEY]
                         [--video_id YOUTUBE_VIDEO_ID]
                         [--endpoint API_ENDPOINT_URL]
                         STATINK_PAYLOAD_FILE
upload_payload.py: error: the following arguments are required: STATINK_PAYLOAD_FILE
```

Signed-off-by: Takeshi HASEGAWA <hasegaw@gmail.com>