### PR TITLE
Add on_game_chained_kill_combo()

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -382,6 +382,7 @@ class IkaEngine:
             scenes.GameStart(self),
             scenes.GameGoSign(self),
             scenes.GameKill(self),
+            scenes.GameKillCombo(self),
             scenes.GameDead(self),
             scenes.GameOutOfBound(self),
             scenes.GameFinish(self),

--- a/ikalog/outputs/console.py
+++ b/ikalog/outputs/console.py
@@ -42,7 +42,10 @@ class Console(object):
         print(_('Game Start. Stage: %(stage)s, Mode: %(rule)s') % {'rule': rule, 'stage':map})
 
     def on_game_killed(self, context):
-        print(_('Splatted an enemy!'))
+        print(_('Splatted an enemy! (%(streak)d streak)') % {'streak' : context['game'].get('kill_streak', 1)})
+
+    def on_game_chained_kill_combo(self, context):
+        print(_('You chained %(combo)d kill combo(s)!') % {'combo' : context['game'].get('kill_combo', 1)})
 
     def on_game_dead(self, context):
         print(_('You were splatted!'))

--- a/ikalog/outputs/debug.py
+++ b/ikalog/outputs/debug.py
@@ -53,6 +53,9 @@ class DebugLog(object):
     def on_game_killed(self, context):
         self.write_debug_log(sys._getframe().f_code.co_name, context)
 
+    def on_game_chained_kill_combo(self, context):
+        self.write_debug_log(sys._getframe().f_code.co_name, context)
+
     def on_game_dead(self, context):
         self.write_debug_log(sys._getframe().f_code.co_name, context)
 

--- a/ikalog/scenes/__init__.py
+++ b/ikalog/scenes/__init__.py
@@ -21,6 +21,7 @@
 from .game.start import GameStart
 from .game.go_sign import GameGoSign
 from .game.kill import GameKill
+from .game.kill_combo import GameKillCombo
 from .game.dead import GameDead
 from .game.finish import GameFinish
 from .game.timer_icon import GameTimerIcon

--- a/ikalog/scenes/game/kill_combo.py
+++ b/ikalog/scenes/game/kill_combo.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  IkaLog
+#  ======
+#  Copyright (C) 2015 Takeshi HASEGAWA, Shingo MINAMIYAMA
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import sys
+
+import cv2
+
+from ikalog.scenes.scene import Scene
+from ikalog.utils import *
+
+class GameKillCombo(Scene):
+
+    def reset(self):
+        super(GameKillCombo, self).reset()
+        self.resetParams()
+        self.max_kill_streak = 0
+        self.max_kill_combo = 0
+
+    def resetParams(self):
+        self.chain_kill_combos = 0
+        self.kill_streak = 0
+        self.last_kill_msec = 0
+
+    def match_no_cache(self, context):
+        if not self.is_another_scene_matched(context, 'GameTimerIcon'):
+            return False
+
+        frame = context['engine']['frame']
+
+        if frame is None:
+            return False
+
+    def on_game_killed(self, context):
+        self.kill_streak += 1
+        context['game']['kill_streak'] = self.kill_streak
+        context['game']['max_kill_streak'] = max(self.kill_streak, context['game'].get('max_kill_streak', 0))
+
+        if (self.kill_streak > 1 and (context['engine']['msec'] - self.last_kill_msec) <= 5000):
+            self.chain_kill_combos += 1
+            context['game']['kill_combo'] = self.chain_kill_combos
+            context['game']['max_kill_combo'] = max(self.chain_kill_combos, context['game'].get('max_kill_combo', 0))
+
+            self._call_plugins('on_game_chained_kill_combo')
+        else:
+            self.chain_kill_combos = 0;
+
+        self.last_kill_msec = context['engine']['msec']
+
+    def on_game_dead(self, context):
+        self.resetParams()
+
+    def _analyze(self, context):
+        pass
+
+    def _init_scene(self, debug=False):
+        pass
+
+if __name__ == "__main__":
+    GameKillCombo.main_func()


### PR DESCRIPTION
- To fire an event at kill_combo(within 5000 ms) in game.
- Record the count of kill_combo and kill_streak for debug and console.
- add parameters to context follows:
   - context['game']['kill_combo']
   - context['game']['kill_streak']
   - context['game']['max_kill_combo']
   - context['game']['max_kill_streak']
