### PR TITLE
Return results about kill_combo and kill_streak to stat.ink

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -353,12 +353,6 @@ class StatInk(object):
         if len(context['game']['death_reasons'].keys()) > 0:
             payload['death_reasons'] = context['game']['death_reasons'].copy()
 
-        if context['game'].get('max_kill_combo'):
-            payload['max_kill_combo'] = int(context['game']['max_kill_combo'])
-
-        if context['game'].get('max_kill_streak'):
-            payload['max_kill_streak'] = int(context['game']['max_kill_streak'])
-
         if len(self.events) > 0:
             payload['events'] = list(self.events)
 
@@ -767,10 +761,7 @@ class StatInk(object):
         self._close_game_session(context)
 
     def on_game_killed(self, context):
-        self._add_event(context, {
-            'type': 'killed',
-            'streak': context['game'].get('kill_streak', 1),
-        })
+        self._add_event(context, {'type': 'killed'})
 
     def on_game_chained_kill_combo(self, context):
         self._add_event(context, {

--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -353,6 +353,12 @@ class StatInk(object):
         if len(context['game']['death_reasons'].keys()) > 0:
             payload['death_reasons'] = context['game']['death_reasons'].copy()
 
+        if context['game'].get('max_kill_combo'):
+            payload['max_kill_combo'] = int(context['game']['max_kill_combo'])
+
+        if context['game'].get('max_kill_streak'):
+            payload['max_kill_streak'] = int(context['game']['max_kill_streak'])
+
         if len(self.events) > 0:
             payload['events'] = list(self.events)
 
@@ -761,7 +767,16 @@ class StatInk(object):
         self._close_game_session(context)
 
     def on_game_killed(self, context):
-        self._add_event(context, {'type': 'killed'})
+        self._add_event(context, {
+            'type': 'killed',
+            'streak': context['game'].get('kill_streak', 1),
+        })
+
+    def on_game_chained_kill_combo(self, context):
+        self._add_event(context, {
+            'type': 'chained_kill_combo',
+            'combo': context['game'].get('kill_combo', 1),
+        })
 
     def on_game_dead(self, context):
         self.last_dead_event = {'type': 'dead'}


### PR DESCRIPTION
- Return result about chained_kill_combo event for 'events'
- Return result about streak parameter into on_game_killed event for 'events'.
- Return results about max_kill_combo and max_kill_streak.
- This pull request is based on follow request:
   -  https://github.com/hasegaw/IkaLog/pull/269