### PR TITLE
Fixed a bug that 'gal's were not recognized correctly.

### DIFF
--- a/ikalog/api/server.py
+++ b/ikalog/api/server.py
@@ -110,10 +110,21 @@ class APIServer(object):
 
     def recoginize_weapons(self, payload):
         weapons_list = []
+
+        # '.52ガロン' was previously written as 'ガロン52'. Since KNN model data
+        # still uses this name, we need to normalize the name.
+        normalization_dict = {
+            'ガロン52': '.52ガロン',
+            'ガロン96': '.96ガロン',
+            'ガロンデコ52': '.52ガロンデコ',
+            'ガロンデコ96': '.96ガロンデコ',
+        }
+
         for img_bytes in payload:
             img = cv2.imdecode(np.fromstring(img_bytes, dtype='uint8'), 1)
             assert img is not None
             result, distance = weapons.predict(img)
+            result = normalization_dict.get(result, result)
 
             # FIXME: 現状返ってくる key が日本語表記なので id に変換
             weapon_id = None


### PR DESCRIPTION
* This bug was caused by https://github.com/hasegaw/IkaLog/commit/7a5077839ab3ca069b8bd619f1a18d57ee808da2
* KNN model data still uses the 'ガロン52' format.
* This is a temporary workaround.
* The right way is to update tools/learn_weapons.py and data/weapons.knn.data.