### PR TITLE
Simplified the code in IkaLog.py and generalized the logic.

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -356,9 +356,18 @@ class IkaEngine:
 
     def set_capture(self, capture):
         self.capture = capture
-        self.context['engine']['input_class'] = self.capture.__class__.__name__
+        self.context['engine']['input_class'] = capture.__class__.__name__
+        self.context['engine']['epoch_time'] = capture.get_epoch_time()
 
-    def set_epoch_time(self, epoch_time):
+    def set_epoch_time(self, arg):
+        if not arg:
+            # Do nothing. Keep the current value.
+            return
+
+        epoch_time = None
+        if arg != 'now':
+            epoch_time = time.mktime(time.strptime(arg, '%Y%m%d_%H%M%S'))
+
         self.context['engine']['epoch_time'] = epoch_time
 
     def set_plugins(self, plugins):

--- a/ikalog/inputs/input.py
+++ b/ikalog/inputs/input.py
@@ -252,6 +252,12 @@ class VideoInput(object):
     def get_current_timestamp(self):
         return self._get_current_timestamp_func()
 
+    def get_epoch_time(self):
+        return None
+
+    def set_pos_msec(self, pos_msec):
+        pass
+
     ##
     # set_frame_rate(self, fps=None, realtime=False)
     #

--- a/ikalog/inputs/opencv_file.py
+++ b/ikalog/inputs/opencv_file.py
@@ -65,7 +65,9 @@ class CVFile(VideoInput):
             # FIXME: Does it work with non-ascii path?
             self.video_capture = cv2.VideoCapture(source)
             self._source_file = source
-            if not self.video_capture.isOpened():
+            if self.video_capture.isOpened():
+                self._epoch_time = self.get_start_time()
+            else:
                 self.video_capture = None
             self.reset_tick()
 
@@ -111,6 +113,10 @@ class CVFile(VideoInput):
 
         return frame
 
+    # override
+    def get_epoch_time(self):
+        return self._epoch_time
+
     def get_start_time(self):
         """Returns the timestamp of the beginning of this video in sec."""
         if (not self._source_file) or (not self.video_capture):
@@ -124,6 +130,7 @@ class CVFile(VideoInput):
 
         return last_modified_time - duration
 
+    # override
     def set_pos_msec(self, pos_msec):
         """Moves the video position to |pos_msec| in msec."""
         self.video_capture.set(cv2.CAP_PROP_POS_MSEC, pos_msec)
@@ -131,6 +138,7 @@ class CVFile(VideoInput):
     def __init__(self):
         self.video_capture = None
         self._source_file = None
+        self._epoch_time = None
         super(CVFile, self).__init__()
 
     # backward compatibility

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -28,6 +28,7 @@
 import unittest
 import os.path
 import sys
+import time
 
 # Append the Ikalog root dir to sys.path to import IkaUtils.
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -78,7 +79,8 @@ class TestEngine(unittest.TestCase):
         # None is the default as the current time.
         self.assertIsNone(context['engine']['epoch_time'])
 
-        IKA_EPOCH = 1432784096.0  # '20150528_123456' in sec.
+        IKA_EPOCH = time.mktime(time.strptime('20150528_123456',
+                                              '%Y%m%d_%H%M%S'))
         engine.set_epoch_time('20150528_123456')
         self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
 

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -70,5 +70,27 @@ class TestEngine(unittest.TestCase):
         engine.session_abort()
         self.assertEqual(5, context['game']['index'])
 
+    def test_set_epoch_time(self):
+        engine = ikalog.engine.IkaEngine()
+        engine.reset()
+        context = engine.context
+
+        # None is the default as the current time.
+        self.assertIsNone(context['engine']['epoch_time'])
+
+        IKA_EPOCH = 1432784096.0  # '20150528_123456' in sec.
+        engine.set_epoch_time('20150528_123456')
+        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
+
+        # '' or None does not change the current value.
+        engine.set_epoch_time('')
+        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
+        engine.set_epoch_time(None)
+        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
+
+        # None is the default as the current time.
+        engine.set_epoch_time('now')
+        self.assertIsNone(context['engine']['epoch_time'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* For --time flag, added set_pos_msec to VideoInput and CVFile.
  + time_to_msec() was merged to get_pos_msec()
  + init_for_cvfile() was merged to get_pos_msec()

* For --epoch_time flag, added get_epoch_time to VideoInput and CVFile and
  added set_epoch_time to IkaEngine.
  + get_epoch_time() was divided to IkaEngine.set_epoch_time() and
    CVFile.get_epoch_time()