### PR TITLE
Removed --epoch_time command line flag.

### DIFF
--- a/IkaConfig.py.sample
+++ b/IkaConfig.py.sample
@@ -62,7 +62,12 @@ INPUT_ARGS['AVFoundationCapture'] = {'source': 'THE_DEVICE_ID'}
 # - You can override source filename with --input_file options.
 #
 # INPUT_SOURCE = 'CVFile'
-INPUT_ARGS['CVFile'] = {'source': 'video.avi', 'frame_rate': 10}
+INPUT_ARGS['CVFile'] = {
+    'source': 'video.avi',
+    'frame_rate': 10,
+    # Use input file's timestamp instead of the current time.
+    'use_file_timestamp': True,
+}
 
 # GStreamer: Read from GStreamer
 # - You need OpenCV runtime with GStreamer support.

--- a/IkaLog.py
+++ b/IkaLog.py
@@ -56,8 +56,6 @@ def get_args():
                         default=False)
     parser.add_argument('--time', '-t', dest='time', type=str)
     parser.add_argument('--time_msec', dest='time_msec', type=int)
-    parser.add_argument('--epoch_time', dest='epoch_time', type=str,
-                        help='In the format like 20150528_235900 or "now".')
     parser.add_argument('--video_id', dest='video_id', type=str)
     parser.add_argument('--debug', dest='debug', action='store_true',
                         default=False)
@@ -85,7 +83,6 @@ if __name__ == "__main__":
     engine = IkaEngine(enable_profile=args.get('profile'))
     engine.pause(False)
     engine.set_capture(capture)
-    engine.set_epoch_time(args['epoch_time'])
 
     engine.set_plugins(output_plugins)
     for op in output_plugins:

--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -361,17 +361,6 @@ class IkaEngine:
         self.context['engine']['epoch_time'] = capture.get_epoch_time()
         self.context['engine']['source_file'] = capture.get_source_file()
 
-    def set_epoch_time(self, arg):
-        if not arg:
-            # Do nothing. Keep the current value.
-            return
-
-        epoch_time = None
-        if arg != 'now':
-            epoch_time = time.mktime(time.strptime(arg, '%Y%m%d_%H%M%S'))
-
-        self.context['engine']['epoch_time'] = epoch_time
-
     def set_plugins(self, plugins):
         self.output_plugins = [self]
         self.output_plugins.extend(self.scenes)

--- a/ikalog/inputs/opencv_file.py
+++ b/ikalog/inputs/opencv_file.py
@@ -115,7 +115,10 @@ class CVFile(VideoInput):
 
     # override
     def get_epoch_time(self):
-        return self._epoch_time
+        if self._use_file_timestamp:
+           return self._epoch_time
+        else:
+            return None
 
     def get_start_time(self):
         """Returns the timestamp of the beginning of this video in sec."""
@@ -139,10 +142,14 @@ class CVFile(VideoInput):
     def get_source_file(self):
         return self._source_file
 
+    def set_use_file_timestamp(self, use_file_timestamp=True):
+        self._use_file_timestamp = use_file_timestamp
+
     def __init__(self):
         self.video_capture = None
         self._source_file = None
         self._epoch_time = None
+        self._use_file_timestamp = True
         super(CVFile, self).__init__()
 
     # backward compatibility

--- a/ikalog/utils/config_loader.py
+++ b/ikalog/utils/config_loader.py
@@ -75,6 +75,7 @@ def _init_source(opts):
         source.select_source(name=(opts.get('input_file') or
                                    input_args.get('source')))
         source.set_frame_rate(input_args.get('frame_rate'))
+        source.set_use_file_timestamp(input_args.get('use_file_timestamp'))
         return source
 
     # パターン6: OpenCV の GStreamerパイプラインからの読み込み機能を利用する

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -71,28 +71,6 @@ class TestEngine(unittest.TestCase):
         engine.session_abort()
         self.assertEqual(5, context['game']['index'])
 
-    def test_set_epoch_time(self):
-        engine = ikalog.engine.IkaEngine()
-        engine.reset()
-        context = engine.context
-
-        # None is the default as the current time.
-        self.assertIsNone(context['engine']['epoch_time'])
-
-        IKA_EPOCH = time.mktime(time.strptime('20150528_123456',
-                                              '%Y%m%d_%H%M%S'))
-        engine.set_epoch_time('20150528_123456')
-        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
-
-        # '' or None does not change the current value.
-        engine.set_epoch_time('')
-        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
-        engine.set_epoch_time(None)
-        self.assertEqual(IKA_EPOCH, context['engine']['epoch_time'])
-
-        # None is the default as the current time.
-        engine.set_epoch_time('now')
-        self.assertIsNone(context['engine']['epoch_time'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
INPUT_ARGS['CVFile']['use_file_timestamp'] is the alternative to --epoch_time.

I also made sure the case that IkaConfig.py does not set INPUT_ARGS['CVFile']['use_file_timestamp'].