### PR TITLE
Enable to accept multiple input files.

### DIFF
--- a/IkaLog.py
+++ b/IkaLog.py
@@ -42,7 +42,7 @@ def get_args():
                         choices=['DirectShow', 'CVCapture', 'ScreenCapture',
                                  'AVFoundationCapture', 'CVFile'])
     parser.add_argument('--input_file', '-f', dest='input_file', type=str,
-                        help='Input video file. '
+                        nargs='*', help='Input video file. '
                         'Other flags can refer this flag as __INPUT_FILE__')
     parser.add_argument('--output_json', '--json',
                         dest='output_json', type=str)

--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -341,7 +341,10 @@ class IkaEngine:
                     else:
                         self.session_abort()
 
-                self._stop = True
+                if self.capture.on_eof():
+                    self.reset_capture()
+                else:
+                    self._stop = True
 
     def run(self):
         try:
@@ -357,9 +360,12 @@ class IkaEngine:
 
     def set_capture(self, capture):
         self.capture = capture
-        self.context['engine']['input_class'] = capture.__class__.__name__
-        self.context['engine']['epoch_time'] = capture.get_epoch_time()
-        self.context['engine']['source_file'] = capture.get_source_file()
+        self.reset_capture()
+
+    def reset_capture(self):
+        self.context['engine']['input_class'] = self.capture.__class__.__name__
+        self.context['engine']['epoch_time'] = self.capture.get_epoch_time()
+        self.context['engine']['source_file'] = self.capture.get_source_file()
 
     def set_plugins(self, plugins):
         self.output_plugins = [self]

--- a/ikalog/inputs/input.py
+++ b/ikalog/inputs/input.py
@@ -185,15 +185,17 @@ class VideoInput(object):
 
         next_tick = None
 
-        if self.cap_recorded_video:
-            self._skip_frame_recorded()
-        else:
-            next_tick = self._skip_frame_realtime()
+        try:
+            if self.cap_recorded_video:
+                self._skip_frame_recorded()
+            else:
+                next_tick = self._skip_frame_realtime()
 
-        self._next_frame_func()
+            self._next_frame_func()
 
-        img = self._read_frame_func()
-        self.lock.release()
+            img = self._read_frame_func()
+        finally:
+            self.lock.release()
 
         if img is None:
             return None
@@ -261,6 +263,10 @@ class VideoInput(object):
     # Returns the source file if the input is from a file. Otherwise None.
     def get_source_file(self):
         return None
+
+    # Callback on EOFError. Returns True if a next data source is available.
+    def on_eof(self):
+        return False
 
     ##
     # set_frame_rate(self, fps=None, realtime=False)


### PR DESCRIPTION
Usage:
  IkaLog.py --input_file a.mp4 b.mp4 c.mp4

Caveat:
  Output file is overwritten by the last input_file.
  For example, when the command is 'IkaLog -f a.mp4 b.mp4 --json ika.json',
  ika.json contains only data for 'b.mp4'.

  'IkaLog -f a.mp4 b.mp4 --json __INPUT_FILE__.json' works as expected.

* Added VideoInput.on_eof as a callback called on EOFError.
* Added IkaEngine.reset_capture which is called from set_capture and also
  on EOFError and VideoInput.on_eof returns true.
* Made sure the lock is release in VideoInput.read_frame even on exception.