### PR TITLE
Enabled to keep the corresponding context for on_output_statink funcs

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -90,8 +90,10 @@ class IkaEngine:
     def dprint(self, text):
         print(text, file=sys.stderr)
 
-    def call_plugin(self, plugin, event_name, params=None, debug=False):
-        context = self.context
+    def call_plugin(self, plugin, event_name,
+                    params=None, debug=False, context=None):
+        if not context:
+            context = self.context
 
         if hasattr(plugin, event_name):
             if debug:
@@ -119,14 +121,15 @@ class IkaEngine:
                 self.dprint(traceback.format_exc())
                 self.dprint('<<<<<')
 
-    def call_plugins(self, event_name, params=None, debug=False):
-        context = self.context
+    def call_plugins(self, event_name, params=None, debug=False, context=None):
+        if not context:
+            context = self.context
 
         if debug:
             self.dprint('call plug-in hook (%s):' % event_name)
 
         for op in self.output_plugins:
-            self.call_plugin(op, event_name, params, debug)
+            self.call_plugin(op, event_name, params, debug, context)
 
     def call_plugins_later(self, event_name, params=None, debug=False):
         self._event_queue.append((event_name, params))

--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -47,11 +47,6 @@ except:
 
 # IkaLog Output Plugin for Stat.ink
 
-
-def call_plugins_mock(event_name, params=None, debug=False):
-    pass
-
-
 class StatInk(object):
 
     def apply_ui(self):
@@ -619,39 +614,35 @@ class StatInk(object):
             IkaUtils.dprint('%s: Failed to write msgpack file' % self)
             IkaUtils.dprint(traceback.format_exc())
 
-    def _post_payload_worker(self, context, payload, api_key):
+    def _post_payload_worker(self, context, payload, api_key,
+                             call_plugins_func=None):
         # This function runs on worker thread.
-
         error, statink_response = UploadToStatInk(payload,
                                                   api_key,
                                                   self.url_statink_v1_battle,
                                                   self.show_response_enabled,
                                                   (self.dry_run == 'server'))
 
+        if not call_plugins_func:
+            return
+
         # Trigger a event.
-
-        try:
-            call_plugins_func = \
-                context['engine']['service']['call_plugins_later']
-        except:
-            call_plugins_func = call_plugins_mock
-
         if error:
             call_plugins_func(
                 'on_output_statink_submission_error',
-                params=statink_response
+                params=statink_response, context=context
             )
 
         elif statink_response.get('id', 0) == 0:
             call_plugins_func(
                 'on_output_statink_submission_dryrun',
-                params=statink_response
+                params=statink_response, context=context
             )
 
         else:
             call_plugins_func(
                 'on_output_statink_submission_done',
-                params=statink_response
+                params=statink_response, context=context
             )
 
     def post_payload(self, context, payload, api_key=None):
@@ -672,8 +663,12 @@ class StatInk(object):
         if api_key is None:
             raise('No API key specified')
 
+        copied_context = IkaUtils.copy_context(context)
+        call_plugins_func = context['engine']['service']['call_plugins_later']
+
         thread = threading.Thread(
-            target=self._post_payload_worker, args=(context, payload, api_key))
+            target=self._post_payload_worker,
+            args=(copied_context, payload, api_key, call_plugins_func))
         thread.start()
 
     def print_payload(self, payload):

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -19,6 +19,7 @@
 #
 from __future__ import print_function
 
+import copy
 import os
 import platform
 import re
@@ -265,3 +266,14 @@ class IkaUtils(object):
 
         base, ext = os.path.splitext(filename)
         return '%s-%d%s' % (base, index, ext)
+
+    @staticmethod
+    def copy_context(context):
+        """Copies context as deep copy without Python objects."""
+        context2 = context.copy()  # shallow copy
+        context2['engine'] = context['engine'].copy()  # shallow copy
+        # Because some Python objects cannot be copied as deepcopy,
+        # these values are replaced with None before deepcopy.
+        context2['engine']['engine'] = None  # IkaEngine
+        context2['engine']['service'] = {}  # functions of IkaEngine
+        return copy.deepcopy(context2)

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -33,6 +33,7 @@ import time
 # Append the Ikalog root dir to sys.path to import IkaUtils.
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ikalog.engine
+from ikalog.utils import *
 
 class TestEngine(unittest.TestCase):
     def test_reset(self):
@@ -70,6 +71,16 @@ class TestEngine(unittest.TestCase):
         # take care about if session_close was called before.
         engine.session_abort()
         self.assertEqual(5, context['game']['index'])
+
+    def test_copy_context(self):
+        engine = ikalog.engine.IkaEngine()
+        engine.reset()
+        context = IkaUtils.copy_context(engine.context)
+        self.assertEqual(context['game']['kills'],
+                         engine.context['game']['kills'])
+        context['game']['kills'] = 99
+        self.assertNotEqual(context['game']['kills'],
+                            engine.context['game']['kills'])
 
 
 if __name__ == '__main__':

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -405,5 +405,20 @@ class TestIkaUtils(unittest.TestCase):
                          IkaUtils.get_file_name('__INPUT_FILE__.statink',
                                                 mock_context))
 
+    def test_copy_context(self):
+        mock_context = {
+            'engine': {
+                'engine': self,
+                'source_file': 'video.mp4',
+                'service': {'call_plugins_later': self.test_copy_context}}}
+
+        copied_context = IkaUtils.copy_context(mock_context)
+        copied_context['engine']['source_file'] = 'movie.ts'
+        self.assertEqual('video.mp4', mock_context['engine']['source_file'])
+        self.assertEqual('movie.ts', copied_context['engine']['source_file'])
+        self.assertIsNone(copied_context['engine']['engine'])
+        self.assertIsNone(
+            copied_context['engine']['service'].get('call_plugins_later'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When on_output_statink_* functions are called, the values of 'context' is
already filled with a new next game in the current implementation.

This change keeps the context and passes it to callback plugins.