### PR TITLE
Fixed a runtime error of IkaUtils.copy_context().

### DIFF
--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -276,4 +276,7 @@ class IkaUtils(object):
         # these values are replaced with None before deepcopy.
         context2['engine']['engine'] = None  # IkaEngine
         context2['engine']['service'] = {}  # functions of IkaEngine
+        context2['game'] = context['game'].copy()  # shallow copy
+        context2['game']['map'] = None  # IkaMatcher
+        context2['game']['rule'] = None  # IkaMatcher
         return copy.deepcopy(context2)

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -406,19 +406,35 @@ class TestIkaUtils(unittest.TestCase):
                                                 mock_context))
 
     def test_copy_context(self):
+        mock_map = IkaMatcherMock('kinmedai')
+        mock_rule = IkaMatcherMock('area')
         mock_context = {
             'engine': {
                 'engine': self,
                 'source_file': 'video.mp4',
-                'service': {'call_plugins_later': self.test_copy_context}}}
+                'service': {'call_plugins_later': self.test_copy_context},
+            },
+            'game': {
+                'map': mock_map,
+                'rule': mock_rule,
+            }}
 
         copied_context = IkaUtils.copy_context(mock_context)
         copied_context['engine']['source_file'] = 'movie.ts'
         self.assertEqual('video.mp4', mock_context['engine']['source_file'])
         self.assertEqual('movie.ts', copied_context['engine']['source_file'])
+
+        self.assertIsNotNone(mock_context['engine']['engine'])
+        self.assertIsNotNone(
+            mock_context['engine']['service'].get('call_plugins_later'))
+        self.assertIsNotNone(mock_context['game']['map'])
+        self.assertIsNotNone(mock_context['game']['rule'])
+
         self.assertIsNone(copied_context['engine']['engine'])
         self.assertIsNone(
             copied_context['engine']['service'].get('call_plugins_later'))
+        self.assertIsNone(copied_context['game']['map'])
+        self.assertIsNone(copied_context['game']['rule'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* context['game']['map'] and context['game']['rule'] are also Python objects
  which cannot be copied by deepcopy.