### PR TITLE
Created IkaUtils.get_path.

### DIFF
--- a/ikalog/inputs/filters/warp_model.py
+++ b/ikalog/inputs/filters/warp_model.py
@@ -124,11 +124,8 @@ class WarpFilterModel(object):
         super(WarpFilterModel, self).__init__()
 
         for lang in Localization.get_game_languages():
-            model_filename = os.path.join(
-                IkaUtils.baseDirectory(),
-                'data',
-                'webcam_calibration.%s.model' % lang
-            )
+            model_filename = IkaUtils.get_path(
+                'data', 'webcam_calibration.%s.model' % lang)
             if os.path.exists(model_filename):
                 break
 
@@ -146,15 +143,14 @@ class WarpFilterModel(object):
             calibration_image = cv2.imread('camera/ika_usbcam/Pause.png', 0)
             self.calibration_image_size = calibration_image.shape[:2]
             calibration_image_hight, calibration_image_width = \
-                calibration_image.shape[ :2] 
+                calibration_image.shape[ :2]
             self.calibration_image_keypoints, self.calibration_image_descriptors = \
                 self.detector.detectAndCompute( calibration_image, None)
 
             print(self.calibration_image_keypoints)
             print(self.calibration_image_descriptors)
 
-            model_filename = os.path.join(
-                IkaUtils.baseDirectory(),
+            model_filename = IkaUtils.get_path(
                 'data',
                 'webcam_calibration.%s.model' % Localization.get_game_languages()[0]
             )

--- a/ikalog/scenes/result_detail.py
+++ b/ikalog/scenes/result_detail.py
@@ -146,8 +146,8 @@ class ResultDetail(StatefulScene):
         IkaUtils.dprint('%s: Created model data %s' % (self, dest_filename))
 
     def load_akaze_model(self):
-        model_filename = os.path.join(
-            IkaUtils.baseDirectory(), 'data', 'result_detail_features.akaze.model')
+        model_filename = IkaUtils.get_path(
+            'data', 'result_detail_features.akaze.model')
 
         try:
             self.load_model_from_file(model_filename)
@@ -859,16 +859,14 @@ class ResultDetail(StatefulScene):
             debug=False,
         )
 
-        base_dir = IkaUtils.baseDirectory()
         languages = Localization.get_game_languages()
         for lang in languages:
-            mask_file = os.path.join(
-                base_dir, 'masks', lang, 'result_detail.png')
+            mask_file = IkaUtils.get_path('masks', lang, 'result_detail.png')
             if os.path.exists(mask_file):
                 break
 
         if not os.path.exists(mask_file):
-            mask_file = os.path.join(base_dir, 'masks', 'result_detail.png')
+            mask_file = IkaUtils.get_path('masks', 'result_detail.png')
         winlose = imread(mask_file)
         self.winlose_gray = cv2.cvtColor(winlose, cv2.COLOR_BGR2GRAY)
 

--- a/ikalog/utils/certifi.py
+++ b/ikalog/utils/certifi.py
@@ -25,7 +25,7 @@ class Certifi(object):
 
     @staticmethod
     def where():
-        cacert_pem = os.path.join(IkaUtils.baseDirectory(), 'cacert.pem')
+        cacert_pem = IkaUtils.get_path('cacert.pem')
         if os.path.exists(cacert_pem):
             return cacert_pem
 

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -50,16 +50,23 @@ class IkaUtils(object):
         print(text, file=sys.stderr)
 
     @staticmethod
-    def baseDirectory():
-        base_directory = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        base_directory = re.sub('[\\/]+$', '', base_directory)
+    def get_path(*dirs):
+        '''Returns the path prepended the top dir and appened subdirs.'''
+        path = ''
+        if dirs:
+            path = os.path.join(*dirs)
+            if os.path.isabs(path):
+                return path
 
-        if os.path.isfile(base_directory):
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        base_dir = re.sub('[\\/]+$', '', base_dir)
+
+        if os.path.isfile(base_dir):
             # In this case, this version of IkaLog is py2exe'd,
-            # and base_directory is still pointing at the executable.
-            base_directory = os.path.dirname(base_directory)
+            # and base_dir is still pointing at the executable.
+            base_dir = os.path.dirname(base_dir)
 
-        return base_directory
+        return os.path.abspath(os.path.join(base_dir, path))
 
     # Find the local player.
     #

--- a/ikalog/utils/matcher.py
+++ b/ikalog/utils/matcher.py
@@ -114,19 +114,19 @@ class IkaMatcher(object):
                 languages = [lang]
 
             for lang in languages:
-                f = os.path.join(IkaUtils.baseDirectory(), 'masks', lang, img_file)
+                f = IkaUtils.get_path('masks', lang, img_file)
                 if os.path.exists(f):
                     return f
 
-        f = os.path.join(IkaUtils.baseDirectory(), 'masks', img_file)
+        f = IkaUtils.get_path('masks', img_file)
         if os.path.exists(f):
             return f
 
-        f = os.path.join(IkaUtils.baseDirectory(), img_file)
+        f = IkaUtils.get_path(img_file)
         if os.path.exists(f):
             return f
 
-        f = os.path.join(IkaUtils.baseDirectory(), 'masks', 'ja', img_file)
+        f = IkaUtils.get_path('masks', 'ja', img_file)
         if os.path.exists(f):
             IkaUtils.dprint('%s: mask %s: using ja version' %
                 (self, img_file))

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -38,6 +38,21 @@ class TestIkaUtils(unittest.TestCase):
     #
     # Test Cases
     #
+    def test_get_path(self):
+        self.assertTrue(os.path.isfile(IkaUtils.get_path('IkaLog.py')))
+        self.assertTrue(os.path.isdir(IkaUtils.get_path('test')))
+        self.assertTrue(os.path.isdir(IkaUtils.get_path()))
+        self.assertEqual(os.path.abspath(__file__),
+                         IkaUtils.get_path('test', 'utils', 'test_ikautils.py'))
+
+        if IkaUtils.isWindows():
+            pass
+            # TODO: add test cases
+        else:
+            abspath = '/tmp/test/dir'
+            self.assertEqual(abspath, IkaUtils.get_path(abspath))
+
+
     def test_getMyEntryFromContext(self):
         context = {'game': {}}
         self.assertIsNone(IkaUtils.getMyEntryFromContext(context))


### PR DESCRIPTION
* Removed IkaUtils.baseDirectory and merged it to IkaUtils.get_path.
* We will be able to run IkaLog.py from any directory, if all file
  accessing code uses IkaUtils.get_path.