### PR TITLE
Added context['game']['events'] and context['game']['offset_msec']

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -152,6 +152,7 @@ class IkaEngine:
         context['engine']['msec'] = t
         context['engine']['frame'] = frame
         context['engine']['preview'] = copy.deepcopy(frame)
+        context['game']['offset_msec'] = IkaUtils.get_game_offset_msec(context)
 
         self.call_plugins('on_debug_read_next_frame')
 
@@ -190,6 +191,11 @@ class IkaEngine:
 
             'inkling_state': [None, None],
 
+            # Dict mapping from event_name (e.g. objective) to lists of lists
+            # of msec time and value.
+            # e.g. 'events': {'objective': [[0, 0], [320, 99]]}
+            'events': {},
+
             # Float values of start and end times scince the epoch in second.
             # They are used with IkaUtils.GetTime.
             'start_time': None,
@@ -198,6 +204,8 @@ class IkaEngine:
             # They are used with context['engine']['msec']
             'start_offset_msec': None,
             'end_offset_msec': None,
+            # Time from start_offset_msec in msec.
+            'offset_msec': None,
         }
         self.call_plugins('on_game_reset')
         self._exception_log_init(self.context)

--- a/ikalog/scenes/game/inklings_tracker.py
+++ b/ikalog/scenes/game/inklings_tracker.py
@@ -263,6 +263,8 @@ class InklingsTracker(StatefulScene):
         if self._last_bitmap != bitmap:
             self._call_plugins('on_game_inkling_state_update')
             self._last_bitmap = bitmap
+            IkaUtils.add_event(
+                context, 'inklings', context['game']['inkling_state'])
 
         if 0:
             print(my_team, counter_team)

--- a/ikalog/scenes/game/objective_tracker.py
+++ b/ikalog/scenes/game/objective_tracker.py
@@ -122,6 +122,7 @@ class ObjectiveTracker(Scene):
         context['game']['tower']['max'] = new_max
         if updated:
             self._call_plugins('on_game_objective_position_update')
+            IkaUtils.add_event(context, 'objective', new_pos)
 
         self._last_update_msec = context['engine']['msec']
         return True

--- a/ikalog/scenes/game/splatzone_tracker.py
+++ b/ikalog/scenes/game/splatzone_tracker.py
@@ -177,6 +177,9 @@ class SplatzoneTracker(Scene):
         context['game']['splatzone_counter_team_counter'] = self._counter2
 
         if (counter1[1] != 0) or (counter2[1] != 0) or (loss1[1] != 0) or (loss2[1] != 0):
+            IkaUtils.add_event(
+                context, 'splatzone', [self._counter1['value'],
+                                       self._counter2['value']])
             self._call_plugins('on_game_splatzone_counter_update')
 
     def _analyze(self, context):

--- a/ikalog/utils/ikautils.py
+++ b/ikalog/utils/ikautils.py
@@ -236,6 +236,28 @@ class IkaUtils(object):
             return datetime.now()
 
     @staticmethod
+    def get_game_offset_msec(context):
+        """Returns the offset time in msec since the game start."""
+        if (context['engine'].get('msec') and
+            context['game'].get('start_offset_msec')):
+            return (context['engine']['msec'] -
+                    context['game']['start_offset_msec'])
+        return None
+
+    @staticmethod
+    def add_event(context, key, value):
+        events = context['game'].setdefault('events', {}).setdefault(key, [])
+        game_time = IkaUtils.get_game_offset_msec(context)
+
+        # events is a list of lists of [time, value].
+        if events and events[-1][0] == game_time:
+            event = events[-1]
+            event[1] = value
+        else:
+            event = [game_time, value]
+            events.append(event)
+
+    @staticmethod
     def get_file_name(filename, context):
         """Returns filename modifying index and macro values."""
         if not filename:

--- a/test/utils/test_ikautils.py
+++ b/test/utils/test_ikautils.py
@@ -314,6 +314,29 @@ class TestIkaUtils(unittest.TestCase):
                          time.strftime("%Y%m%d_%H%M%S",
                                        time.localtime(time_actual)))
 
+    def test_get_game_offset_msec(self):
+        mock_context = {'game': {}, 'engine': {}}
+        self.assertIsNone(IkaUtils.get_game_offset_msec(mock_context))
+        mock_context['engine']['msec'] = 1234567
+        self.assertIsNone(IkaUtils.get_game_offset_msec(mock_context))
+        mock_context['game']['start_offset_msec'] = 1000000
+        self.assertEqual(234567, IkaUtils.get_game_offset_msec(mock_context))
+
+    def test_add_event(self):
+        mock_context = {'game': {'start_offset_msec': 100},
+                        'engine': {'msec': 101}}
+        IkaUtils.add_event(mock_context, 'key', 7)
+        self.assertEqual({'key': [[1, 7]]}, mock_context['game']['events'])
+        IkaUtils.add_event(mock_context, 'key', 11)
+        self.assertEqual({'key': [[1, 11]]}, mock_context['game']['events'])
+        IkaUtils.add_event(mock_context, 'key2', 13)
+        self.assertEqual({'key': [[1, 11]], 'key2': [[1, 13]]},
+                         mock_context['game']['events'])
+
+        mock_context['engine']['msec'] = 102
+        IkaUtils.add_event(mock_context, 'key', 7)
+        self.assertEqual({'key': [[1, 11], [2, 7]], 'key2': [[1, 13]]},
+                         mock_context['game']['events'])
 
     def test_get_file_name(self):
         mock_context = {'game': {'index': 0},


### PR DESCRIPTION
* These variables will be used for WebAPI.

* 'events' stores sequences of events as a dict.
* Currently, it stores:
  + inkling alive state
  + splatzone or objective state
  * Added IkaUtils.add_event for helper function.

* 'offset_msec' stores the current time in msec since the game start.
* Added IkaUtils.get_game_offset_msec for helper function.