### PR TITLE
Fixed an issue that IkaLog.py with webserter does not stop.

### DIFF
--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -355,7 +355,7 @@ class IkaEngine:
                 if self.capture.on_eof():
                     self.reset_capture()
                 else:
-                    self._stop = True
+                    self.stop()
 
     def run(self):
         try:


### PR DESCRIPTION
webserver/preview.py stops when on_stop was called, however
it was not called when EOFError raised.