### PR TITLE
Enabled to wait for video files and made WebAPI to receive files.

### DIFF
--- a/IkaConfig.py.sample
+++ b/IkaConfig.py.sample
@@ -67,6 +67,8 @@ INPUT_ARGS['CVFile'] = {
     'frame_rate': 10,
     # Use input file's timestamp instead of the current time.
     'use_file_timestamp': True,
+    # Whether exit or not when all input files are processed.
+    'keep_alive' = False,
 }
 
 # GStreamer: Read from GStreamer

--- a/ikalog/engine.py
+++ b/ikalog/engine.py
@@ -161,6 +161,7 @@ class IkaEngine:
     def stop(self):
         if not self._stop:
             self.call_plugins('on_stop')
+            self.put_source_file(None)
         self._stop = True
 
     def is_stopped(self):
@@ -334,6 +335,9 @@ class IkaEngine:
         while len(self._event_queue) > 0:
             event = self._event_queue.pop(0)
             self.call_plugins(event_name=event[0], params=event[1], context=event[2])
+
+    def put_source_file(self, file_path):
+        return self.capture.put_source_file(file_path)
 
     def _main_loop(self):
         while not self._stop:

--- a/ikalog/inputs/input.py
+++ b/ikalog/inputs/input.py
@@ -259,6 +259,11 @@ class VideoInput(object):
     def get_source_file(self):
         return None
 
+    # Puts file_path to be processed and returns True,
+    # otherwise returns False if the instance does not support this method.
+    def put_source_file(self, file_path):
+        return False
+
     # Callback on EOFError. Returns True if a next data source is available.
     def on_eof(self):
         return False

--- a/ikalog/outputs/webserver/server.py
+++ b/ikalog/outputs/webserver/server.py
@@ -61,6 +61,18 @@ class APIServer(object):
                        default=_get_type_name),
             'utf-8'))
 
+    def _engine_source(self, request_handler, payload):
+        engine = request_handler.server.ikalog_context['engine']['engine']
+        file_path = payload.get('file_path')
+        if (not file_path) or (not engine.put_source_file(file_path)):
+            file_path = 'error'
+
+        request_handler.send_response(200)
+        request_handler.send_header(
+            'Content-type', 'text/plain; charset=UTF-8')
+        request_handler.end_headers()
+        request_handler.wfile.write(bytearray(file_path, 'utf-8'))
+
     def _engine_preview(self, request_handler, payload):
         handler = PreviewRequestHandler(request_handler)
 
@@ -72,6 +84,7 @@ class APIServer(object):
             '/view': self._view_game,
             '/graph': self._graph_game,
             '/api/v1/engine/context/game': self._engine_context_game,
+            '/api/v1/engine/source': self._engine_source,
             '/api/v1/engine/preview': self._engine_preview,
             '/api/v1/engine/stop': self._engine_stop,
         }.get(path, None)

--- a/ikalog/ui/capture.py
+++ b/ikalog/ui/capture.py
@@ -65,6 +65,13 @@ class VideoCapture(object):
             return None
         return self.capture.get_source_file()
 
+    # Puts file_path to be processed and returns True,
+    # otherwise returns False if the instance does not support this method.
+    def put_source_file(self, file_path):
+        if self.capture is None:
+            return False
+        return self.capture.put_source_file(file_path)
+
     # Callback on EOFError. Returns True if a next data source is available.
     def on_eof(self):
         if self.capture is None:

--- a/ikalog/utils/config_loader.py
+++ b/ikalog/utils/config_loader.py
@@ -71,7 +71,7 @@ def _init_source(opts):
     # OpenCV が FFMPEG に対応していること
     # 直接ファイルを指定するか、コマンドラインから --input_file で指定可能
     if input_type == 'CVFile':
-        source = inputs.CVFile()
+        source = inputs.CVFile(keep_alive=input_args.get('keep_alive'))
         source.select_source(name=(opts.get('input_file') or
                                    input_args.get('source')))
         source.set_frame_rate(input_args.get('frame_rate'))


### PR DESCRIPTION
The following command can add a file to be processed.
curl -X POST -d '{"file_path": "/tmp/video.mp4"}' http://localhost:8888/api/v1/engine/source

WARNING:
If RESTAPIServer is enabled with the default setting,
other users in the same machine will be also able to put video files.

* Created put_source_file to set additional video files.
* Added 'keep_alive' option to CVFile.
  + If it's true, when all video files are processed,
    IkaLog waits for new video files.
* Renamed CVFile._source_files to _file_queue and used Queue instead of list.
* Added WebAPI /api/v1/engine/source