### PR TITLE
Enabled to start with no input file.

### DIFF
--- a/ikalog/inputs/input.py
+++ b/ikalog/inputs/input.py
@@ -278,9 +278,6 @@ class VideoInput(object):
     # @param fps      frames per second to be read
     # @param realtime Realtime mode if True.
     def set_frame_rate(self, fps=None, realtime=False):
-        if not self.is_active():
-            return
-
         self.fps_requested = fps
         self.frame_skip_rt = realtime
 

--- a/ikalog/inputs/opencv_file.py
+++ b/ikalog/inputs/opencv_file.py
@@ -70,6 +70,8 @@ class CVFile(VideoInput):
     # override
     def put_source_file(self, file_path):
         self._file_queue.put(file_path)
+        if not self.video_capture:
+            self._init_with_sources()
         return True
 
     # override
@@ -162,7 +164,8 @@ class CVFile(VideoInput):
     # override
     def set_pos_msec(self, pos_msec):
         """Moves the video position to |pos_msec| in msec."""
-        self.video_capture.set(cv2.CAP_PROP_POS_MSEC, pos_msec)
+        if self.video_capture:
+            self.video_capture.set(cv2.CAP_PROP_POS_MSEC, pos_msec)
 
     # override
     def get_source_file(self):


### PR DESCRIPTION
Example:
./IkaLog.py -f ''

* It will enable to start GUI / WebUI with no input file.
* Changed update the frame rates regardless Input's activeness.
* put_source_file initializes CVFile again if CVFile is not active.
  + On the first initialization, _init_with_sources should return soon,
    otherwise output plugins (e.g. RESTAPIServer) cannot be initialized.