### PR TITLE
Fixed a missing special% event

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -708,6 +708,7 @@ class StatInk(object):
         self.events = []
         self.time_last_score_msec = None
         self.time_last_objective_msec = None
+        self.time_last_special_gauge_msec = None 
         self.last_dead_event = None
         self._called_close_game_session = False
 


### PR DESCRIPTION
special%イベントをstat.inkへのpayloadへ追加するときに、前回のイベントから200ms経過していることという判断をしています。しかし、前回のイベント発生を記録する変数が、マッチ間でリセットされていないため、連戦するとそれまでの経過時間が過ぎるまで、イベントがpayloadに追加されなくなっています。