### PR TITLE
Fixed wrong max kill combo

### DIFF
--- a/ikalog/scenes/game/kill_combo.py
+++ b/ikalog/scenes/game/kill_combo.py
@@ -58,7 +58,9 @@ class GameKillCombo(Scene):
 
             self._call_plugins('on_game_chained_kill_combo')
         else:
-            self.chain_kill_combos = 0;
+            self.chain_kill_combos = 1; 
+            context['game']['kill_combo'] = self.chain_kill_combos 
+            context['game']['max_kill_combo'] = max(self.chain_kill_combos, context['game'].get('max_kill_combo', 0)) 
 
         self.last_kill_msec = context['engine']['msec']
 


### PR DESCRIPTION
コンボ条件を満たしていないときにchain_kill_combosが0になっているので、2コンボしたときに、+1されて1が設定されるため、最大コンボ数が実際より1小さくなっています。