### PR TITLE
Fix a DeprecationWarning

### DIFF
--- a/ikalog/inputs/win/videoinput_wrapper.py
+++ b/ikalog/inputs/win/videoinput_wrapper.py
@@ -140,7 +140,7 @@ class VideoInputWrapper(object):
         )
 
         assert buf_size > 0
-        bpp = buf_size / w / h
+        bpp = buf_size // (w * h)
         assert bpp == int(bpp)
         return (h, w, bpp)
 


### PR DESCRIPTION
```
C:\path\to\ikalog\inputs\win\videoinput_wrapper.py:150: VisibleDeprecationWarning: using a non-integer number instead of aninteger will result in an error in the future
    frame_buffer = np.zeros(geom, np.uint8)
```