### PR TITLE
scenes/result_(detail|gears): deepcopy the frame and hold the

### DIFF
--- a/ikalog/outputs/statink.py
+++ b/ikalog/outputs/statink.py
@@ -740,7 +740,7 @@ class StatInk(object):
     # @param context   IkaLog context
     #
     def on_result_detail_still(self, context):
-        self.img_result_detail = context['engine']['frame']
+        self.img_result_detail = context['game']['image_scoreboard']
         IkaUtils.dprint('%s: Gathered img_result (%s)' %
                         (self, self.img_result_detail.shape))
 
@@ -778,7 +778,7 @@ class StatInk(object):
         self.post_payload(context, payload)
 
     def on_result_gears_still(self, context):
-        self.img_gears = context['engine']['frame']
+        self.img_gears = context['game']['image_gears']
         IkaUtils.dprint('%s: Gathered img_gears (%s)' %
                         (self, self.img_gears.shape))
 

--- a/ikalog/outputs/twitter.py
+++ b/ikalog/outputs/twitter.py
@@ -509,7 +509,7 @@ class Twitter(object):
     # @param context   IkaLog context
     #
     def on_result_detail_still(self, context):
-        self.img_result_detail = context['engine']['frame']
+        self.img_result_detail = context['game']['image_scoreboard']
 
     def on_game_session_end(self, context):
         IkaUtils.dprint('%s (enabled = %s)' % (self, self.enabled))

--- a/ikalog/scenes/result_detail.py
+++ b/ikalog/scenes/result_detail.py
@@ -29,10 +29,8 @@ import threading
 import traceback
 from datetime import datetime
 
-
 import cv2
 import numpy as np
-
 
 from ikalog.api import APIClient
 from ikalog.scenes.stateful_scene import StatefulScene
@@ -789,6 +787,8 @@ class ResultDetail(StatefulScene):
 
         # そのほか
         # context['game']['timestamp'] = datetime.now()
+        context['game']['image_scoreboard'] = \
+            copy.deepcopy(context['engine']['frame'])
         self._call_plugins_later('on_result_detail_still')
 
         return True

--- a/ikalog/scenes/result_gears.py
+++ b/ikalog/scenes/result_gears.py
@@ -17,6 +17,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+import copy
 import sys
 import traceback
 
@@ -84,6 +86,8 @@ class ResultGears(StatefulScene):
             # The values, especially cash, will be overwritten by
             # the results of the last frame, but may be used for fallbacks.
             matched = self._analyze(frame, context)
+            context['game']['image_gears'] = \
+                copy.deepcopy(context['engine']['frame'])
             self._call_plugins('on_result_gears_still')
 
         if matched:


### PR DESCRIPTION
reference in context.

Some output classes and input classes hold reference of
context['engine']['frame'] but some (zero-copy implemented)
input classes may re-use the object to hold new frames.

Scene classes should hold single deep-copied image that can be
shared by output plugins.

Signed-off-by: Takeshi HASEGAWA <hasegaw@gmail.com>