### PR TITLE
add full C implemented Python extension kernel 'HAL'

### DIFF
--- a/ikalog/utils/ikamatcher2/matcher.py
+++ b/ikalog/utils/ikamatcher2/matcher.py
@@ -215,8 +215,12 @@ def load_kernel():
     global default_kernel
 
     if platform.machine().startswith('armv7'):
-        from ikalog.utils.ikamatcher2.arm_neon import NEON
-        default_kernel = NEON
+        try:
+            from lib.ikamatcher2_kernel_hal import HAL
+            default_kernel = HAL
+        except:
+            from ikalog.utils.ikamatcher2.arm_neon import NEON
+            default_kernel = NEON
 
     else:
         from ikalog.utils.ikamatcher2.reference import Numpy_uint8_fast

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,7 @@
 CC=gcc
 
-HAL_OBJS=ikamatcher2_neon_hal.o ikamatcher2_neon_wrap.o
+FULL_NATIVE_NEON_HAL_OBJS=ikamatcher2_neon_hal.o ikamatcher2_neon_wrap_new.o ikamatcher2_kernel_hal.o
+SEMI_NATIVE_NEON_HAL_OBJS=ikamatcher2_neon_hal.o ikamatcher2_neon_wrap.o
 PY_INC=`python3 -c "import sysconfig; print(sysconfig.get_path('include'))"`
 INCLUDE_DIR=-I. -I$(PY_INC)
 
@@ -8,18 +9,23 @@ INCLUDE_DIR=-I. -I$(PY_INC)
 CPU=-mtune=cortex-a7 -mfpu=neon
 CFLAGS=-std=c11 -O2 -MD
 
-all: ikamatcher2_neon_hal.so
+all: ikamatcher2_kernel_hal.so ikamatcher2_neon_hal.so
 
-ikamatcher2_neon_hal.so: $(HAL_OBJS)
+ikamatcher2_kernel_hal.so: $(FULL_NATIVE_NEON_HAL_OBJS)
+	$(CC) $(CFLAGS) $(CPU) -fPIC $(INCLUDE_DIR) --shared -o $@ $^
+
+ikamatcher2_neon_hal.so: $(SEMI_NATIVE_NEON_HAL_OBJS)
 	$(CC) $(CFLAGS) $(CPU) -fPIC $(INCLUDE_DIR) --shared -o $@ $^
 
 .c.o:
 	$(CC) $(CFLAGS) $(CPU) -fPIC $(INCLUDE_DIR) -c $<
 
 clean:
-	rm $(HAL_OBJS)
-	rm ikamatcher2_neon_hal.so
-	rm $(HAL_OBJS:.o=.d)
+	-rm $(FULL_NATIVE_NEON_HAL_OBJS)
+	-rm $(SEMI_NATIVE_NEON_HAL_OBJS)
+	-rm ikamatcher2_kernel_hal.so ikamatcher2_neon_hal.so
+	-rm $(FULL_NATIVE_NEON_HAL_OBJS:.o=.d)
+	-rm $(SEMI_NATIVE_NEON_HAL_OBJS:.o=.d)
 
-DEPS = $(HAL_OBJS:.o=.d)
+DEPS = $(FULL_NATIVE_NEON_HAL_OBJS:.o=.d) $(SEMI_NATIVE_NEON_HAL_OBJS:.o=.d)
 -include $(DEPS)

--- a/lib/ikamatcher2_kernel_hal.c
+++ b/lib/ikamatcher2_kernel_hal.c
@@ -1,0 +1,207 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+// http://docs.python.jp/3/howto/cporting.html
+
+#include <Python.h>
+#include "numpy/arrayobject.h"
+#include <stdint.h>
+#include "ikamatcher2_kernel_hal.h"
+
+struct module_state {
+    PyObject *error;
+};
+
+struct IkaMatHALObject {
+  PyObject_HEAD
+  uint32_t w, h;
+  PyArrayObject* mask;
+};
+
+struct HAL_METHODS* hal;
+struct HAL_METHODS* Kernel_init();
+
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+
+static PyObject*
+Ikamatcher2_hal_encode(struct IkaMatHALObject* self, PyObject* args)
+{
+  // get numpy.array([], numpy.uint8)
+  PyArrayObject *src_pyobj;
+    if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &src_pyobj)) {
+     return NULL;
+    }
+
+    PyArrayObject* flat = (PyArrayObject*)PyArray_Ravel(src_pyobj, NPY_ANYORDER );
+    if ( flat == NULL) {
+      PyErr_SetString(PyExc_TypeError, "error converting to flat");
+      return NULL;
+    }
+    PyObject* pyobj_dest = hal->encode(PyArray_BYTES(flat), PyArray_NBYTES(flat));
+
+    Py_XDECREF(flat);
+    return pyobj_dest;
+}
+
+static PyObject* Ikamatcher2_hal_decode(struct IkaMatHALObject* self, PyObject* args) {
+  PyArrayObject *image_pyobj;
+
+  if (!PyArg_ParseTuple(args,"O!", &PyArray_Type, &image_pyobj)) {
+    return NULL;
+  }
+
+  PyObject* pyobj_dest = hal->decode(PyArray_BYTES(image_pyobj), PyArray_NBYTES(image_pyobj));
+  return pyobj_dest;
+}
+
+static PyObject*
+Ikamatcher2_hal_logical_and_popcount(struct IkaMatHALObject* self, PyObject* args)
+{
+  // get numpy.array([], numpy.uint8)
+  PyArrayObject *image_pyobj;
+
+  if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &image_pyobj)){
+    return NULL;
+  }
+
+  uint32_t popcnt = hal->logical_and_popcount(PyArray_BYTES(image_pyobj), PyArray_BYTES(self->mask), self->w * self->h);
+
+  return Py_BuildValue("i", popcnt);
+}
+
+static PyObject*
+Ikamatcher2_hal_logical_or_popcount(struct IkaMatHALObject* self, PyObject* args)
+{
+  PyArrayObject *image_pyobj;
+
+  if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &image_pyobj)){
+      return NULL;
+  }
+
+  uint32_t popcnt = hal->logical_or_popcount(PyArray_BYTES(image_pyobj), PyArray_BYTES(self->mask), self->w * self->h );
+
+  return Py_BuildValue("i", popcnt);
+}
+
+static PyObject* Ikamatcher2_hal_load_mask(struct IkaMatHALObject* self, PyObject* args) {
+  PyArrayObject* mask_obj;
+
+  if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &mask_obj)) {
+    return Py_BuildValue("i",-1);
+  }
+
+  PyArrayObject* flat = (PyArrayObject*)PyArray_Flatten(mask_obj, NPY_CORDER);
+  if ( flat == NULL) {
+    PyErr_SetString(PyExc_TypeError, "error converting to flat");
+    return Py_BuildValue("i",-1);
+  }
+
+  self->mask = (PyArrayObject*)hal->encode(PyArray_BYTES(flat), PyArray_NBYTES(flat));
+
+  Py_XDECREF(flat);
+  return Py_BuildValue("i",0);
+}
+
+static PyMethodDef IkaMatHAL_Methods[] = {
+  {"encode", (PyCFunction)Ikamatcher2_hal_encode, METH_VARARGS},
+  {"decode", (PyCFunction)Ikamatcher2_hal_decode, METH_VARARGS},
+  {"load_mask", (PyCFunction)Ikamatcher2_hal_load_mask, METH_VARARGS},
+  {"logical_and_popcnt", (PyCFunction)Ikamatcher2_hal_logical_and_popcount, METH_VARARGS},
+  {"logical_or_popcnt", (PyCFunction)Ikamatcher2_hal_logical_or_popcount, METH_VARARGS},
+  {NULL}, // sentinel
+};
+
+static void IkaMatHAL_dealloc(struct IkaMatHALObject* self) {
+  Py_XDECREF(self->mask);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject* IkaMatHAL_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+  struct IkaMatHALObject* self;
+  self = (struct IkaMatHALObject*)type->tp_alloc(type, 0);
+  return (PyObject*)self;
+}
+
+static int IkaMatHAL_init(struct IkaMatHALObject* self, PyObject* args, PyObject* kwds) {
+  static char*kwlist[] = {"width", "height", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "II", kwlist, &self->w, &self->h)) {
+	  return -1;
+  }
+
+  return 0;
+}
+
+static PyTypeObject IkaMatHAL_type = {
+  PyVarObject_HEAD_INIT(NULL,0)
+  "ikamatcher2.HAL",
+  sizeof(struct IkaMatHALObject),
+  0,
+  (destructor)IkaMatHAL_dealloc,
+  0,                         /* tp_print */
+  0,                         /* tp_getattr */
+  0,                         /* tp_setattr */
+  0,                         /* tp_reserved */
+  0,                         /* tp_repr */
+  0,                         /* tp_as_number */
+  0,                         /* tp_as_sequence */
+  0,                         /* tp_as_mapping */
+  0,                         /* tp_hash  */
+  0,                         /* tp_call */
+  0,                         /* tp_str */
+  0,                         /* tp_getattro */
+  0,                         /* tp_setattro */
+  0,                         /* tp_as_buffer */
+      Py_TPFLAGS_DEFAULT |
+  Py_TPFLAGS_BASETYPE,   /* tp_flags */
+  "IkaMatcher HAL objects",           /* tp_doc */
+  0,                         /* tp_traverse */
+  0,                         /* tp_clear */
+  0,                         /* tp_richcompare */
+  0,                         /* tp_weaklistoffset */
+  0,                         /* tp_iter */
+  0,                         /* tp_iternext */
+  IkaMatHAL_Methods,             /* tp_methods */
+  0,             /* tp_members */
+  0,                         /* tp_getset */
+  0,                         /* tp_base */
+  0,                         /* tp_dict */
+  0,                         /* tp_descr_get */
+  0,                         /* tp_descr_set */
+  0,                         /* tp_dictoffset */
+  (initproc)IkaMatHAL_init,      /* tp_init */
+  0,                         /* tp_alloc */
+  IkaMatHAL_new,                 /* tp_new */
+};
+
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT,
+  "ikamatcher2_kernel_hal",
+  "IkaMatcher2 HAL Wrapper",
+  -1,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+#define INITERROR return NULL
+
+PyMODINIT_FUNC
+PyInit_ikamatcher2_kernel_hal(void)
+{
+  hal = Kernel_init();
+
+  if(PyType_Ready(&IkaMatHAL_type) < 0) {
+	return NULL;
+  }
+
+    PyObject *module = PyModule_Create(&moduledef);
+	if (module == NULL) {
+	  return NULL;
+	}
+
+	Py_INCREF(&IkaMatHAL_type);
+	PyModule_AddObject(module, "HAL", (PyObject*)&IkaMatHAL_type);
+	import_array();
+	return module;
+}

--- a/lib/ikamatcher2_kernel_hal.h
+++ b/lib/ikamatcher2_kernel_hal.h
@@ -1,0 +1,14 @@
+#ifndef __IKAMATCHER2_KERNEL_HAL_H__
+#define __IKAMATCHER2_KERNEL_HAL_H__
+
+#include <Python.h>
+#include <stdint.h>
+
+struct HAL_METHODS {
+  PyObject* (*encode)(const uint8_t*, uint32_t);
+  PyObject* (*decode)(const uint8_t*, uint32_t);
+  uint32_t (*logical_and_popcount)(const uint8_t*, const uint8_t*, uint32_t);
+  uint32_t (*logical_or_popcount)(const uint8_t*, const uint8_t*, uint32_t);
+};
+
+#endif

--- a/lib/ikamatcher2_neon_wrap_new.c
+++ b/lib/ikamatcher2_neon_wrap_new.c
@@ -1,0 +1,99 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+// http://docs.python.jp/3/howto/cporting.html
+
+#include <Python.h>
+#include "numpy/arrayobject.h"
+
+#include <stdint.h>
+#include "ikamatcher2_kernel_hal.h"
+#include "ikamatcher2_neon_hal.h"
+
+#define ENCODE_SRC_ALIGN 128
+#define ENCODE_DEST_ALIGN 64
+
+static PyObject*
+NEON_encode(const uint8_t* src, uint32_t src_size)
+{
+  // get numpy.array([], numpy.uint8)
+  npy_intp dims[1];
+  uint8_t *a_src, *a_dest;
+  uint8_t need_free = 0;
+  uint32_t a_src_size;
+  uint32_t a_dest_size;
+
+  a_src_size = src_size;
+  a_src = (uint8_t*)src;
+  if ((uint32_t)a_src_size & (ENCODE_SRC_ALIGN-1)) {
+    a_src_size += (ENCODE_SRC_ALIGN - (a_src_size & (ENCODE_SRC_ALIGN-1)));
+    a_src = aligned_alloc(ENCODE_SRC_ALIGN, a_src_size);
+    if (a_src == NULL) {
+      PyErr_SetString(PyExc_MemoryError, "not enough memory");
+      return NULL;
+    }
+    memmove(a_src, src, a_src_size);
+    memset(a_src + src_size, 0, a_src_size - src_size); // clear padding
+    need_free = 1;
+  }
+
+  a_dest_size = a_src_size / 8;
+  if (a_dest_size & (ENCODE_DEST_ALIGN-1)) {
+    a_dest_size += (ENCODE_DEST_ALIGN - (a_dest_size & (ENCODE_DEST_ALIGN-1)));
+  }
+
+  a_dest = aligned_alloc(ENCODE_DEST_ALIGN, a_dest_size);
+
+  if (a_dest == NULL) {
+    PyErr_SetString(PyExc_MemoryError, "not enough memory");
+    return NULL;
+  }
+
+  if (a_dest_size != a_src_size/8) {
+    memset(a_dest+(a_src_size/8), 0, a_dest_size - (a_src_size/8)); // clear padding
+  }
+
+  IkaMatcher2_encode(a_dest, a_src, a_src_size);
+
+  dims[0] = a_dest_size;
+  PyArrayObject* pyobj_a_dest = (PyArrayObject*)PyArray_SimpleNewFromData(1, dims, NPY_UINT8, a_dest);
+  if (pyobj_a_dest == NULL ) {
+    PyErr_SetString(PyExc_TypeError,"error creating PyArrayObject");
+    return NULL;
+  }
+  PyArray_UpdateFlags(pyobj_a_dest, NPY_ARRAY_OWNDATA);
+
+  if (need_free) {
+    free(a_src);
+  }
+
+  return (PyObject*)PyArray_Return(pyobj_a_dest);
+}
+
+static PyObject* NEON_decode(const uint8_t* sec, uint32_t src_size) {
+  return (PyObject*)Py_None;
+}
+
+static uint32_t
+NEON_logical_and_popcount(const uint8_t* img, const uint8_t* mask, uint32_t pixels)
+{
+  // TODO: image and mask buffer need rebuild aligned buffer?
+  return logical_and_popcount_neon_512((uint8_t*)img, (uint8_t*)mask, pixels);
+}
+
+static uint32_t
+NEON_logical_or_popcount(const uint8_t* img, const uint8_t* mask, uint32_t pixels)
+{
+  return logical_or_popcount_neon_512((uint8_t*)img, (uint8_t*)mask, pixels);
+}
+
+static struct HAL_METHODS methods = {
+  NEON_encode,
+  NEON_decode,
+  NEON_logical_and_popcount,
+  NEON_logical_or_popcount
+};
+
+struct HAL_METHODS* Kernel_init() {
+  import_array();
+  return &methods;
+}

--- a/test/bench_1024mat.py
+++ b/test/bench_1024mat.py
@@ -3,6 +3,7 @@ sys.path.append('lib')
 
 from ikalog.utils.ikamatcher2.reference import Numpy_uint8, Numpy_uint8_fast
 from ikalog.utils.ikamatcher2.arm_neon import NEON
+from lib.ikamatcher2_kernel_hal import HAL
 import numpy as np
 import time
 
@@ -32,4 +33,4 @@ def test(kernel):
 test(Numpy_uint8)
 test(Numpy_uint8_fast)
 test(NEON)
-
+test(HAL)


### PR DESCRIPTION
ikamatcher2/arm_neonカーネルのフルC実装版カーネルです。
メモリーアライメント周りは、バッファコピーが重いので必要最低限にとどめて、misalign memoryロードのペナルティーを受け入れる形にしてます。

カーネル名は適当なので、Intel系実装する段階で変えても良いです。
Intel版実装はikamatcher2_kernel_hal.cを使い回しつつな実装を想定してます。

decodeは未使用のようなのでnot implementedです。