### PR TITLE
reduce offset detect

### DIFF
--- a/ikalog/inputs/filters/offset.py
+++ b/ikalog/inputs/filters/offset.py
@@ -193,7 +193,7 @@ class OffsetFilter(Filter):
         w = min(out_width - dx1, out_width - sx1)
         h = min(out_height - dy1, out_height - sy1)
 
-        new_frame = np.zeros((out_height, out_width, 3), np.uint8)
+        new_frame = np.zeros(frame.shape, np.uint8)
         new_frame[dy1:dy1 + h, dx1:dx1 + w] = frame[sy1:sy1 + h, sx1:sx1 + w]
         return new_frame
 

--- a/ikalog/scenes/result_detail.py
+++ b/ikalog/scenes/result_detail.py
@@ -261,10 +261,11 @@ class ResultDetail(StatefulScene):
         best_match = (context['engine']['frame'], 0.0, 0, 0)
         offset_list = [0, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5]
 
+        gray_frame = cv2.cvtColor(context['engine']['frame'], cv2.COLOR_BGR2GRAY)
         for ox in offset_list:
             for oy in offset_list:
                 filter.offset = (ox, oy)
-                img = filter.execute(context['engine']['frame'])
+                img = filter.execute(gray_frame)
                 score = self.evaluate_image_accuracy(img)
 
                 if best_match[1] < score:
@@ -275,14 +276,18 @@ class ResultDetail(StatefulScene):
                         'frame': img,
                         'score': score,
                         'desc': 'Offset (%s, %s)' % (ox, oy),
+                        'offset': (ax, ay)
                     })
 
         if best_match[2] != 0 or best_match[3] != 0:
+            filter.offset = (best_match[2], best_match[3])
+            new_frame = filter.execute(context['engine']['frame'])
             l.append({
-                'frame': best_match[0],
+                'frame': new_frame,
                 'score': score,
                 'desc': 'Offset (%s, %s)' % (best_match[2], best_match[3]),
                 'acceptable': True,
+                'offset': (best_match[2], best_match[3]),
             })
 
     def adjust_image(self, context):
@@ -302,6 +307,8 @@ class ResultDetail(StatefulScene):
                     'on_result_detail_log',
                     params={'desc': best['desc']}
                 )
+            if best.get('offset',None):
+                self._call_plugins('on_result_detail_calibration', best.get('offset'))
 
         else:
             # Should not reach here


### PR DESCRIPTION
detail_resultで検出したオフセット値をdetail_gearsで流用し、オフセット検出の回数を削減。
オフセット検出もあらかじめグレイスケールに変換した画像を使うようにし、処理データ量を削減。
オフセットがズレているデータが無いため要検証です。

ベンチデータ
https://gist.github.com/gleentea/b9b8800d5b7ac97df6a8be276125c67a
オフセット処理を16秒削減