### PR TITLE
Changed screen capture input to capture entire desktop instead of only primary monitor

### DIFF
--- a/ikalog/inputs/win/screencapture.py
+++ b/ikalog/inputs/win/screencapture.py
@@ -22,6 +22,7 @@ import os
 import ctypes
 import time
 import threading
+import win32gui, win32ui, win32con, win32api
 
 import cv2
 import numpy as np
@@ -127,16 +128,34 @@ class ScreenCapture(VideoInput):
         return True
 
     def capture_screen(self):
-        from PIL import ImageGrab
-
         try:
-            img = ImageGrab.grab(None)
-        except TypeError:
-            # なぜ発生することがあるのか、よくわからない
+            hwin = win32gui.GetDesktopWindow()
+            width = win32api.GetSystemMetrics(win32con.SM_CXVIRTUALSCREEN)
+            height = win32api.GetSystemMetrics(win32con.SM_CYVIRTUALSCREEN)
+            left = win32api.GetSystemMetrics(win32con.SM_XVIRTUALSCREEN)
+            top = win32api.GetSystemMetrics(win32con.SM_YVIRTUALSCREEN)
+            hwindc = win32gui.GetWindowDC(hwin)
+            srcdc = win32ui.CreateDCFromHandle(hwindc)
+            memdc = srcdc.CreateCompatibleDC()
+            bmp = win32ui.CreateBitmap()
+            bmp.CreateCompatibleBitmap(srcdc, width, height)
+            memdc.SelectObject(bmp)
+            memdc.BitBlt((0, 0), (width, height), srcdc, (left, top), win32con.SRCCOPY)
+            signedIntsArray = bmp.GetBitmapBits(True)
+            img = np.fromstring(signedIntsArray, dtype='uint8')
+            img.shape = (height,width,4)
+            
+            srcdc.DeleteDC()
+            memdc.DeleteDC()
+            win32gui.ReleaseDC(hwin, hwindc)
+            win32gui.DeleteObject(bmp.GetHandle())
+        except:
+            # sometimes BitBlt will fail, for example when a
+            # Windows User Account Control dialog appears
             IkaUtils.dprint('%s: Failed to grab desktop image' % self)
             return None
-
-        return cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)
+        
+        return cv2.cvtColor(img, cv2.COLOR_RGBA2RGB)
 
     # override
     def _read_frame_func(self):


### PR DESCRIPTION
Changed img = ImageGrab.grab(None) to use pywin32 instead via a BitBlit of win32con.SRCCOPY. This new method captures the entire virtual screen, across all displays. (The old ImageGrab.grab call will only capture the primary display's image, which could be problematic for users with multiple monitors.)

This adds new Windows dependency of pywin32-220.win32-py3.4.exe ( https://sourceforge.net/projects/pywin32/files/pywin32/Build%20220/ )

Note: Users who previously never calibrated and have multiple monitor setups will now need to calibrate. (They can no longer rely on IkaLog defaulting to capture the entire screen of their primary monitor.)