### PR TITLE
Fix commentator

### DIFF
--- a/ikalog/outputs/boyomi.py
+++ b/ikalog/outputs/boyomi.py
@@ -163,8 +163,8 @@ class LegacyBoyomi(BoyomiPlugin):
         config = {
             'host': host,
             'port': port,
-            'dictionary': dirctionary,
-            'dictionary_csv': directionary_csv,
+            'dictionary': dictionary,
+            'dictionary_csv': dictionary_csv,
             'custom_read_csv': custom_read_csv,
         }
         self.set_configuration(config)

--- a/ikalog/outputs/commentator.py
+++ b/ikalog/outputs/commentator.py
@@ -243,7 +243,7 @@ class Commentator(object):
             data['text'] = data['text'].format(kill=kill, death=death)
             self._read(data)
 
-        if (me['score'] is not None) and (context['game']['won'] is not None):
+        if (me.get('score') is not None) and (context['game']['won'] is not None):
             # 判定のしようもないので、300pt時代のことは考えない
             bonus = 1000 if context['game']['won'] else 0
             score = int(me['score'])

--- a/ikalog/outputs/commentator.py
+++ b/ikalog/outputs/commentator.py
@@ -139,7 +139,7 @@ class Commentator(object):
         return config
 
     def _read(self, message):
-        if (not self._enabled):
+        if (not self._enabled) or (message is None) or (len(message['text']) == 0):
             return
 
         try:


### PR DESCRIPTION
- ガチマッチの結果画面で例外が飛ぶ（実害はない）のを修正します
- イベントに対応するデータがない場合に空のデータを読み上げようとする（実害はたぶんない）のを修正します