### PR TITLE
Make sure division yields integer

### DIFF
--- a/ikalog/scenes/result_detail.py
+++ b/ikalog/scenes/result_detail.py
@@ -599,7 +599,7 @@ class ResultDetail(StatefulScene):
         img_deaths = img_entry[entry_height_kd:entry_height_kd *
                                2, entry_xoffset_kd:entry_xoffset_kd + entry_width_kd]
 
-        img_fes_title = img_name[0:entry_height / 2, :]
+        img_fes_title = img_name[0:(entry_height // 2), :]
         img_fes_title_hsv = cv2.cvtColor(img_fes_title, cv2.COLOR_BGR2HSV)
         yellow = cv2.inRange(img_fes_title_hsv[:, :, 0], 32 - 2, 32 + 2)
         yellow2 = cv2.inRange(img_fes_title_hsv[:, :, 2], 240, 255)


### PR DESCRIPTION
In python 3, division by `/` yields float like `46 / 2` yields `23.0` which
shouldn't be input of list index. To make division result integer, it must
be `46 // 2` which yields `23` .

This is a fix for #457 . I'm not sure why this code had been working in my Python 3.5 environment, but this patch fixes the issue and working fine in my machine. Maybe should we check other `/` s usage for list index?