### PR TITLE
Fix broken download links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>IkaLog Download</title>
-    <base href="https://dl.dropboxusercontent.com/u/14421778/IkaLog/">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/2.6.0/css/flag-icon.min.css" crossorigin="anonymous">
+    <link rel="icon" href="https://hasegaw.stat.ink/favicon.png">
     <style>
       body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,Meiryo,sans-serif}
       #logo{width:300px;height:auto;max-width:100%}
@@ -20,7 +20,7 @@
   <body>
     <div class="container">
       <p align="center">
-        <img id="logo" src="ikalog_logo1.png">
+        <img id="logo" src="https://hasegaw.stat.ink/ikalog_logo1.png">
       </p>
       <h1>
         WinIkaLog
@@ -29,9 +29,21 @@
       <h2>
         <span class="fa fa-download fa-fw"></span>ダウンロード / download
       </h2>
-
       <table class="table table-striped">
         <tbody>
+          <tr>
+            <th>人柱版 (Web-based UI, development version)</th>
+            <td>
+              <a href="https://hasegaw.stat.ink/WinIkaLog20170202_004535_76f7726.zip">WinIkaLog20170202_004535_76f7726.zip</a>
+            </td>
+          </tr>
+          <tr>
+            <th>最新版 (Latest version)</th>
+            <td>
+              <a href="https://hasegaw.stat.ink/WinIkaLog20161003_025744_74673bd.zip">WinIkaLog20161003_025744_74673bd.zip</a>
+            </td>
+          </tr>
+<!--
           <tr>
             <th>人柱版 (Dev version, not tested)</th>
             <td><a href="WinIkaLog20160723_174727_8667dd4.zip">WinIkaLog20160723_174727_8667dd4.zip</a></td>
@@ -44,6 +56,7 @@
             <th>安定版 (Stable version)</th>
             <td><a href="WinIkaLog20160609_005508_579408a.zip">WinIkaLog20160609_005508_579408a.zip</a></td>
           </tr>
+-->
         </tbody>
       </table>
 


### PR DESCRIPTION
ダウンロードリンクが死んでいるのを、とりあえず hasegaw.stat.ink に向けることで解消します。
（このホストの実体は stat.ink サーバ(hibiki)にあり、hasegaw さんのアカウントでログインしてそれっぽいディレクトリを覗くとあります）

以前からあったものと手元にある(=hasegaw.stat.ink)においてあるバージョンが違うので、必要であればファイル配置等のうえ、更に更新をかける必要があります。

更新履歴等は一切変更していないので、その辺は別途更新が必要です。