### PR TITLE
Added "ink from a propeller" as it was still missing.

### DIFF
--- a/ikalog/constants.py
+++ b/ikalog/constants.py
@@ -399,6 +399,13 @@ additional_cause_of_death_v2 = {
             'en_US': 'Inkfurler'
         }
     },
+    'propeller': {
+        'key': 'propeller',
+        'name': {
+            'ja_JP': 'プロペラからのインク',
+            'en_US': 'Ink from a propeller',
+        },
+    },
     'senpaicannon': {
         'key': 'senpaicannon',
         'name': {


### PR DESCRIPTION
"Splatted by ink from a propeller!" may occur in Ancho-V Games.

Related commit in stat.ink repo: https://github.com/fetus-hina/stat.ink/commit/830fe83bce79f20ed659cd63459fbe2313314c27